### PR TITLE
Allow use of private app for authentication

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -34,7 +34,7 @@ func SetAPIKey(key string) AuthMethod {
 func SetPrivateAppToken(token string) AuthMethod {
 	return func(c *Client) {
 		c.authenticator = &PrivateAppToken{
-			authToken: token,
+			accessToken: token,
 		}
 	}
 }
@@ -64,11 +64,11 @@ func (a *APIKey) SetAuthentication(r *http.Request) error {
 }
 
 type PrivateAppToken struct {
-	authToken string
+	accessToken string
 }
 
 func (p *PrivateAppToken) SetAuthentication(r *http.Request) error {
 	h := r.Header
-	h.Set("Authorization", "Bearer "+p.authToken)
+	h.Set("Authorization", "Bearer "+p.accessToken)
 	return nil
 }

--- a/auth.go
+++ b/auth.go
@@ -69,6 +69,6 @@ type PrivateAppToken struct {
 
 func (p *PrivateAppToken) SetAuthentication(r *http.Request) error {
 	h := r.Header
-	h.Set("Authorization", "Bearer " + p.authToken)
+	h.Set("Authorization", "Bearer "+p.authToken)
 	return nil
 }

--- a/auth.go
+++ b/auth.go
@@ -31,6 +31,14 @@ func SetAPIKey(key string) AuthMethod {
 	}
 }
 
+func SetPrivateAppToken(token string) AuthMethod {
+	return func(c *Client) {
+		c.authenticator = &PrivateAppToken{
+			authToken: token,
+		}
+	}
+}
+
 type OAuth struct {
 	retriever OAuthTokenRetriever
 }
@@ -52,5 +60,15 @@ func (a *APIKey) SetAuthentication(r *http.Request) error {
 	q := r.URL.Query()
 	q.Set("hapikey", a.apikey)
 	r.URL.RawQuery = q.Encode()
+	return nil
+}
+
+type PrivateAppToken struct {
+	authToken string
+}
+
+func (p *PrivateAppToken) SetAuthentication(r *http.Request) error {
+	h := r.Header
+	h.Set("Authorization", "Bearer " + p.authToken)
 	return nil
 }


### PR DESCRIPTION
## What to do  
This PR introduces an `Authenticator` which simply sets an access token from a configured private app, so that it can be passed in the Authorisation header with requests. This is called out in issue #8 and mentioned in the repo's readme.

## Background  
I'm proposing this change because it is already called out as a change that would be desirable. I find this library useful, and as the linked issue explains, API keys will be deprecated next month so I decided to add this capability to ensure continued use.
[Hubspot private app docs](https://developers.hubspot.com/docs/api/private-apps)

## Acceptance criteria  
This PR should successfully allow any interaction with the HubSpot API that currently works with an API key, with a private app access token configured with the same scopes.

This would be my first contribution to open source software, please be kind :)