### PR TITLE
Add deprecated comments to SetAPIKey and replace usages

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,13 @@ $ go get github.com/belong-inc/go-hubspot
 
 ### API key
 
+**Deprecated**
+
 You should take api key in advance. Follow steps
 in [here](https://knowledge.hubspot.com/integrations/how-do-i-get-my-hubspot-api-key).
 
 ```go
-// Initialize hubspot client with apikey
+// Initialize hubspot client with apikey.
 client, _ := hubspot.NewClient(hubspot.SetAPIKey("YOUR_API_KEY"))
 ```
 
@@ -43,13 +45,23 @@ client, _ := hubspot.NewClient(hubspot.SetOAuth(&hubspot.OAuthConfig{
 }))
 ```
 
+### Private app
+
+You should take access token in advance. Follow steps
+in [here](https://developers.hubspot.com/docs/api/private-apps).
+
+```go
+// Initialize hubspot client with private app access token.
+client, _ := hubspot.NewClient(hubspot.SetPrivateAppToken("YOUR_ACCESS_TOKEN"))
+```
+
 ## API call
 
 ### Get contact
 
 ```go
 // Initialize hubspot client with auth method.
-client, _ := hubspot.NewClient(hubspot.SetAPIKey("YOUR_API_KEY"))
+client, _ := hubspot.NewClient(hubspot.SetPrivateAppToken("YOUR_ACCESS_TOKEN"))
 
 // Get a Contact object whose id is `yourContactID`.
 // Contact instance needs to be provided to bind response value.
@@ -71,7 +83,7 @@ fmt.Println(contact.FirstName, contact.LastName)
 
 ```go
 // Initialize hubspot client with auth method.
-client, _ := hubspot.NewClient(hubspot.SetAPIKey("YOUR_API_KEY"))
+client, _ := hubspot.NewClient(hubspot.SetPrivateAppToken("YOUR_ACCESS_TOKEN"))
 
 // Create request payload.
 req := &hubspot.Contact{
@@ -102,7 +114,7 @@ fmt.Println(contact.FirstName, contact.LastName)
 
 ```go
 // Initialize hubspot client with auth method.
-client, _ := hubspot.NewClient(hubspot.SetAPIKey("YOUR_API_KEY"))
+client, _ := hubspot.NewClient(hubspot.SetPrivateAppToken("YOUR_ACCESS_TOKEN"))
 
 // Call associate api.
 client.CRM.Contact.AssociateAnotherObj("yourContactID", &hubspot.AssociationConfig{
@@ -127,7 +139,7 @@ type CustomDeal struct {
 }
 
 // Initialize hubspot client with auth method.
-client, _ := hubspot.NewClient(hubspot.SetAPIKey("YOUR_API_KEY"))
+client, _ := hubspot.NewClient(hubspot.SetPrivateAppToken("YOUR_ACCESS_TOKEN"))
 
 // Get a Deal object whose id is `yourDealID`.
 // CustomDeal instance needs to be provided as to bind response value contained custom fields.
@@ -160,7 +172,7 @@ type CustomDeal struct {
 }
 
 // Initialize hubspot client with auth method.
-client, _ := hubspot.NewClient(hubspot.SetAPIKey("YOUR_API_KEY"))
+client, _ := hubspot.NewClient(hubspot.SetPrivateAppToken("YOUR_ACCESS_TOKEN"))
 
 req := &CustomDeal{
     Deal: hubspot.Deal{
@@ -205,9 +217,9 @@ fmt.Println(customDeal.CustomA, customDeal.CustomB)
 
 |Type         | Availability |
 |-------------|--------------|
-|API key      | Available |
-|OAuth        | Available |
-|Private apps | Not Implemented |
+|API key      | Deprecated   |
+|OAuth        | Available    |
+|Private apps | Available    |
 
 # Contributing
 

--- a/auth.go
+++ b/auth.go
@@ -23,6 +23,7 @@ func SetOAuth(config *OAuthConfig) AuthMethod {
 	}
 }
 
+// Deprecated: Use hubspot.SetPrivateAppToken.
 func SetAPIKey(key string) AuthMethod {
 	return func(c *Client) {
 		c.authenticator = &APIKey{

--- a/example_test.go
+++ b/example_test.go
@@ -17,7 +17,7 @@ type ExampleContact struct {
 }
 
 func ExampleContactServiceOp_Create() {
-	cli, _ := hubspot.NewClient(hubspot.SetAPIKey(os.Getenv("API_KEY")))
+	cli, _ := hubspot.NewClient(hubspot.SetPrivateAppToken(os.Getenv("PRIVATE_APP_TOKEN")))
 
 	example := &ExampleContact{
 		email:     "hubspot@example.com",
@@ -54,7 +54,7 @@ func ExampleContactServiceOp_Create() {
 }
 
 func ExampleContactServiceOp_Update() {
-	cli, _ := hubspot.NewClient(hubspot.SetAPIKey(os.Getenv("API_KEY")))
+	cli, _ := hubspot.NewClient(hubspot.SetPrivateAppToken(os.Getenv("PRIVATE_APP_TOKEN")))
 
 	example := &ExampleContact{
 		email:     "hubspot@example.com",
@@ -92,7 +92,7 @@ func ExampleContactServiceOp_Update() {
 }
 
 func ExampleContactServiceOp_Get() {
-	cli, _ := hubspot.NewClient(hubspot.SetAPIKey(os.Getenv("API_KEY")))
+	cli, _ := hubspot.NewClient(hubspot.SetPrivateAppToken(os.Getenv("PRIVATE_APP_TOKEN")))
 
 	res, err := cli.CRM.Contact.Get("contact001", &hubspot.Contact{}, nil)
 	if err != nil {
@@ -113,7 +113,7 @@ func ExampleContactServiceOp_Get() {
 }
 
 func ExampleContactServiceOp_AssociateAnotherObj() {
-	cli, _ := hubspot.NewClient(hubspot.SetAPIKey(os.Getenv("API_KEY")))
+	cli, _ := hubspot.NewClient(hubspot.SetPrivateAppToken(os.Getenv("PRIVATE_APP_TOKEN")))
 
 	res, err := cli.CRM.Contact.AssociateAnotherObj("contact001", &hubspot.AssociationConfig{
 		ToObject:   hubspot.ObjectTypeDeal,
@@ -221,6 +221,42 @@ func ExampleDealServiceOp_Create_oauth() {
 	// // Output:
 }
 
+func ExampleDealServiceOp_Create_privateapp() {
+	cli, _ := hubspot.NewClient(hubspot.SetPrivateAppToken(os.Getenv("PRIVATE_APP_TOKEN")))
+
+	example := &ExampleDeal{
+		amount:  "1500.00",
+		name:    "Custom data integrations",
+		stage:   "presentation scheduled",
+		ownerID: "910901",
+	}
+
+	deal := &hubspot.Deal{
+		Amount:      hubspot.NewString(example.amount),
+		DealName:    hubspot.NewString(example.name),
+		DealStage:   hubspot.NewString(example.stage),
+		DealOwnerID: hubspot.NewString(example.ownerID),
+		PipeLine:    hubspot.NewString("default"),
+	}
+
+	res, err := cli.CRM.Deal.Create(deal)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	r, ok := res.Properties.(*hubspot.Deal)
+	if !ok {
+		log.Fatal("unable to type assertion")
+	}
+
+	// use properties
+	_ = r
+
+	fmt.Println(res)
+
+	// // Output:
+}
+
 type CustomDeal struct {
 	hubspot.Deal
 	CustomA string `json:"custom_a,omitempty"`
@@ -228,7 +264,7 @@ type CustomDeal struct {
 }
 
 func ExampleDealServiceOp_Create_custom() {
-	cli, _ := hubspot.NewClient(hubspot.SetAPIKey(os.Getenv("API_KEY")))
+	cli, _ := hubspot.NewClient(hubspot.SetPrivateAppToken(os.Getenv("PRIVATE_APP_TOKEN")))
 
 	example := &ExampleDeal{
 		amount:  "1500.00",
@@ -267,7 +303,7 @@ func ExampleDealServiceOp_Create_custom() {
 }
 
 func ExampleDealServiceOp_Update() {
-	cli, _ := hubspot.NewClient(hubspot.SetAPIKey(os.Getenv("API_KEY")))
+	cli, _ := hubspot.NewClient(hubspot.SetPrivateAppToken(os.Getenv("PRIVATE_APP_TOKEN")))
 
 	example := &ExampleDeal{
 		amount:  "1500.00",
@@ -303,7 +339,7 @@ func ExampleDealServiceOp_Update() {
 }
 
 func ExampleDealServiceOp_Get() {
-	cli, _ := hubspot.NewClient(hubspot.SetAPIKey(os.Getenv("API_KEY")))
+	cli, _ := hubspot.NewClient(hubspot.SetPrivateAppToken(os.Getenv("PRIVATE_APP_TOKEN")))
 
 	res, err := cli.CRM.Deal.Get("deal001", &hubspot.Deal{}, nil)
 	if err != nil {
@@ -324,7 +360,7 @@ func ExampleDealServiceOp_Get() {
 }
 
 func ExampleDealServiceOp_Get_custom() {
-	cli, _ := hubspot.NewClient(hubspot.SetAPIKey(os.Getenv("API_KEY")))
+	cli, _ := hubspot.NewClient(hubspot.SetPrivateAppToken(os.Getenv("PRIVATE_APP_TOKEN")))
 
 	res, err := cli.CRM.Deal.Get("deal001", &CustomDeal{}, &hubspot.RequestQueryOption{
 		CustomProperties: []string{
@@ -350,7 +386,7 @@ func ExampleDealServiceOp_Get_custom() {
 }
 
 func ExampleDealServiceOp_AssociateAnotherObj() {
-	cli, _ := hubspot.NewClient(hubspot.SetAPIKey(os.Getenv("API_KEY")))
+	cli, _ := hubspot.NewClient(hubspot.SetPrivateAppToken(os.Getenv("PRIVATE_APP_TOKEN")))
 
 	res, err := cli.CRM.Deal.AssociateAnotherObj("deal001", &hubspot.AssociationConfig{
 		ToObject:   hubspot.ObjectTypeContact,
@@ -375,7 +411,7 @@ func ExampleDealServiceOp_AssociateAnotherObj() {
 }
 
 func ExampleMarketingEmailOp_GetStatistics() {
-	cli, _ := hubspot.NewClient(hubspot.SetAPIKey(os.Getenv("API_KEY")))
+	cli, _ := hubspot.NewClient(hubspot.SetPrivateAppToken(os.Getenv("PRIVATE_APP_TOKEN")))
 
 	emailID := 0 // Set proper value.
 	res, err := cli.Marketing.Email.GetStatistics(emailID, &hubspot.Statistics{})
@@ -397,7 +433,7 @@ func ExampleMarketingEmailOp_GetStatistics() {
 }
 
 func ExampleMarketingEmailOp_ListStatistics() {
-	cli, _ := hubspot.NewClient(hubspot.SetAPIKey(os.Getenv("API_KEY")))
+	cli, _ := hubspot.NewClient(hubspot.SetPrivateAppToken(os.Getenv("PRIVATE_APP_TOKEN")))
 
 	statistics := make([]hubspot.Statistics, 0, 50)
 	res, err := cli.Marketing.Email.ListStatistics(&hubspot.BulkStatisticsResponse{Objects: statistics}, &hubspot.BulkRequestQueryOption{Limit: 10})

--- a/gohubspot.go
+++ b/gohubspot.go
@@ -56,7 +56,7 @@ type ResponseResource struct {
 
 // NewClient returns a new HubSpot API client with APIKey or OAuthConfig.
 // HubSpot officially recommends authentication with OAuth.
-// e.g. hubspot.NewClient(hubspot.SetAPIKey("key"))
+// e.g. hubspot.NewClient(hubspot.SetPrivateAppToken("key"))
 func NewClient(setAuthMethod AuthMethod, opts ...Option) (*Client, error) {
 	if setAuthMethod == nil {
 		return nil, errors.New("the authentication method is not set")

--- a/gohubspot_test.go
+++ b/gohubspot_test.go
@@ -78,44 +78,57 @@ func TestNewClient(t *testing.T) {
 			wantErr: nil,
 		},
 		{
+			name: "Success new client and set private app token",
+			args: args{
+				setAuthMethod: hubspot.SetPrivateAppToken("token"),
+			},
+			settings: settings{
+				client:     http.DefaultClient,
+				baseURL:    hubspot.ExportBaseURL,
+				apiVersion: hubspot.ExportAPIVersion,
+				authMethod: hubspot.SetPrivateAppToken("token"),
+			},
+			wantErr: nil,
+		},
+		{
 			name: "Success new client with custom http client",
 			args: args{
-				setAuthMethod: hubspot.SetAPIKey("key"),
+				setAuthMethod: hubspot.SetPrivateAppToken("token"),
 				opts:          []hubspot.Option{hubspot.WithHTTPClient(&http.Client{Timeout: 100 * time.Second})},
 			},
 			settings: settings{
 				client:     &http.Client{Timeout: 100 * time.Second},
 				baseURL:    hubspot.ExportBaseURL,
 				apiVersion: hubspot.ExportAPIVersion,
-				authMethod: hubspot.SetAPIKey("key"),
+				authMethod: hubspot.SetPrivateAppToken("token"),
 			},
 			wantErr: nil,
 		},
 		{
 			name: "Success new client with custom base url",
 			args: args{
-				setAuthMethod: hubspot.SetAPIKey("key"),
+				setAuthMethod: hubspot.SetPrivateAppToken("token"),
 				opts:          []hubspot.Option{hubspot.WithBaseURL(&url.URL{Scheme: "http", Host: "example.com"})},
 			},
 			settings: settings{
 				client:     http.DefaultClient,
 				baseURL:    &url.URL{Scheme: "http", Host: "example.com"},
 				apiVersion: hubspot.ExportAPIVersion,
-				authMethod: hubspot.SetAPIKey("key"),
+				authMethod: hubspot.SetPrivateAppToken("token"),
 			},
 			wantErr: nil,
 		},
 		{
 			name: "Success new client with custom api version",
 			args: args{
-				setAuthMethod: hubspot.SetAPIKey("key"),
+				setAuthMethod: hubspot.SetPrivateAppToken("token"),
 				opts:          []hubspot.Option{hubspot.WithAPIVersion("v0")},
 			},
 			settings: settings{
 				client:     http.DefaultClient,
 				baseURL:    hubspot.ExportBaseURL,
 				apiVersion: "v0",
-				authMethod: hubspot.SetAPIKey("key"),
+				authMethod: hubspot.SetPrivateAppToken("token"),
 			},
 			wantErr: nil,
 		},
@@ -279,6 +292,35 @@ func TestClient_NewRequest(t *testing.T) {
 			},
 			wantErr: nil,
 		},
+		{
+			name: "Created http.POST request with PrivateApp token",
+			settings: settings{
+				client:     hubspot.NewMockHTTPClient(&hubspot.MockConfig{}),
+				baseURL:    hubspot.ExportBaseURL,
+				apiVersion: hubspot.ExportAPIVersion,
+				authMethod: hubspot.SetPrivateAppToken("token"),
+				crm:        nil,
+			},
+			args: args{
+				method: http.MethodPost,
+				path:   "objects/test",
+				body: &body{
+					ID:   "001",
+					Name: "example",
+				},
+				option: nil,
+			},
+			want: wantReq{
+				method: http.MethodPost,
+				url:    "https://api.hubapi.com/objects/test",
+				body:   []byte(`{"id":"001","name":"example"}`),
+				header: http.Header{
+					"Content-Type":  []string{"application/json"},
+					"Authorization": []string{"Bearer token"},
+				},
+			},
+			wantErr: nil,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -355,7 +397,7 @@ func TestClient_CreateAndDo(t *testing.T) {
 				}),
 				baseURL:    hubspot.ExportBaseURL,
 				apiVersion: hubspot.ExportAPIVersion,
-				authMethod: hubspot.SetAPIKey("test"),
+				authMethod: hubspot.SetPrivateAppToken("test"),
 				crm:        nil,
 			},
 			args: args{
@@ -393,7 +435,7 @@ func TestClient_CreateAndDo(t *testing.T) {
 				}),
 				baseURL:    hubspot.ExportBaseURL,
 				apiVersion: hubspot.ExportAPIVersion,
-				authMethod: hubspot.SetAPIKey("test"),
+				authMethod: hubspot.SetPrivateAppToken("test"),
 				crm:        nil,
 			},
 			args: args{

--- a/mock_test.go
+++ b/mock_test.go
@@ -30,7 +30,7 @@ func NewMockClient(conf *MockConfig) *Client {
 		apiVersion: defaultAPIVersion,
 	}
 	cli.CRM = newCRM(cli)
-	SetAPIKey("apikey")(cli)
+	SetPrivateAppToken("token")(cli)
 
 	return cli
 }

--- a/options_test.go
+++ b/options_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestWithAPIVersion(t *testing.T) {
 	want := "v0"
-	c, _ := hubspot.NewClient(hubspot.SetAPIKey("key"), hubspot.WithAPIVersion(want))
+	c, _ := hubspot.NewClient(hubspot.SetPrivateAppToken("token"), hubspot.WithAPIVersion(want))
 	if want != c.ExportGetAPIVersion() {
 		t.Errorf("WithAPIVersion() result mismatch: want %s got %s", want, c.ExportGetAPIVersion())
 	}
@@ -20,7 +20,7 @@ func TestWithAPIVersion(t *testing.T) {
 
 func TestWithHTTPClient(t *testing.T) {
 	want := &http.Client{Timeout: 10 * time.Second}
-	c, _ := hubspot.NewClient(hubspot.SetAPIKey("key"), hubspot.WithHTTPClient(want))
+	c, _ := hubspot.NewClient(hubspot.SetPrivateAppToken("token"), hubspot.WithHTTPClient(want))
 	if diff := cmp.Diff(want, c.HTTPClient); diff != "" {
 		t.Errorf("WithHTTPClient() result mismatch: (-want +got):%s", diff)
 	}
@@ -28,7 +28,7 @@ func TestWithHTTPClient(t *testing.T) {
 
 func TestWithBaseURL(t *testing.T) {
 	want := &url.URL{Scheme: "http", Host: "example.com"}
-	c, _ := hubspot.NewClient(hubspot.SetAPIKey("key"), hubspot.WithBaseURL(want))
+	c, _ := hubspot.NewClient(hubspot.SetPrivateAppToken("token"), hubspot.WithBaseURL(want))
 	if diff := cmp.Diff(want, c.ExportGetBaseURL()); diff != "" {
 		t.Errorf("WithBaseURL() result mismatch: (-want +got):%s", diff)
 	}


### PR DESCRIPTION
## What to do  
- Add deprecated comment to `hubspot.SetAPIKey()`
- With the exception of a few tests, where `hubspot.SetAPIKey()` is used, it has been replaced with `hubspot. SetPrivateAppToken()`.
- Added test for private app.

## Background 
Support for HubSpot private apps available, APIKey deprecated soon.
https://developers.hubspot.com/changelog/upcoming-api-key-sunset

## Acceptance criteria  