### PR TITLE
Add support for hubspot single email send via marketing/transactional endpoint.

### DIFF
--- a/marketing.go
+++ b/marketing.go
@@ -11,7 +11,6 @@ type Marketing struct {
 	Transactional TransactionalServiceOp
 }
 
-// "/marketing/v3/transactional/single-email/send"
 func newMarketing(c *Client) *Marketing {
 	return &Marketing{
 		Email: NewMarketingEmail(c),

--- a/marketing.go
+++ b/marketing.go
@@ -1,13 +1,23 @@
 package hubspot
 
+import "fmt"
+
 const (
 	marketingBasePath = "marketing"
 )
 
 type Marketing struct {
-	Email MarketingEmailService
+	Email         MarketingEmailService
+	Transactional TransactionalServiceOp
 }
 
+// "/marketing/v3/transactional/single-email/send"
 func newMarketing(c *Client) *Marketing {
-	return &Marketing{Email: NewMarketingEmail(c)}
+	return &Marketing{
+		Email: NewMarketingEmail(c),
+		Transactional: TransactionalServiceOp{
+			client:            c,
+			transactionalPath: fmt.Sprintf("%s/%s/%s", marketingBasePath, c.apiVersion, transactionalBasePath),
+		},
+	}
 }

--- a/marketing.go
+++ b/marketing.go
@@ -8,13 +8,13 @@ const (
 
 type Marketing struct {
 	Email         MarketingEmailService
-	Transactional TransactionalServiceOp
+	Transactional TransactionalService
 }
 
 func newMarketing(c *Client) *Marketing {
 	return &Marketing{
 		Email: NewMarketingEmail(c),
-		Transactional: TransactionalServiceOp{
+		Transactional: &TransactionalServiceOp{
 			client:            c,
 			transactionalPath: fmt.Sprintf("%s/%s/%s", marketingBasePath, c.apiVersion, transactionalBasePath),
 		},

--- a/marketing_transactional.go
+++ b/marketing_transactional.go
@@ -4,15 +4,13 @@ import "fmt"
 
 const transactionalBasePath = "transactional"
 
-// DealService is an interface of deal endpoints of the HubSpot API.
-// HubSpot deal can be used to manage transactions.
-// It can also be associated with other CRM objects such as contact and company.
-// Reference: https://developers.hubspot.com/docs/api/crm/deals
+// TransactionalService is an interface for the marketing/transactional service of the HubSpot API.
+// Reference: https://developers.hubspot.com/docs/api/marketing/transactional-emails
 type TransactionalService interface {
 	SendSingleEmail(props *SendSingleEmailProperties) (*SendSingleEmailResponse, error)
 }
 
-// DealServiceOp handles communication with the product related methods of the HubSpot API.
+// Provides the default implementation of TransactionService.
 type TransactionalServiceOp struct {
 	transactionalPath string
 	client            *Client

--- a/marketing_transactional.go
+++ b/marketing_transactional.go
@@ -1,0 +1,52 @@
+package hubspot
+
+import "fmt"
+
+const transactionalBasePath = "transactional"
+
+// DealService is an interface of deal endpoints of the HubSpot API.
+// HubSpot deal can be used to manage transactions.
+// It can also be associated with other CRM objects such as contact and company.
+// Reference: https://developers.hubspot.com/docs/api/crm/deals
+type TransactionalService interface {
+	SingleEmailSend(props *SingleSendProperties) (*SingleEmailSendResponse, error)
+}
+
+// DealServiceOp handles communication with the product related methods of the HubSpot API.
+type TransactionalServiceOp struct {
+	transactionalPath string
+	client            *Client
+}
+
+var _ TransactionalService = (*TransactionalServiceOp)(nil)
+
+type SingleSendMessage struct {
+	To      string   `json:"to"`
+	From    string   `json:"from,omitempty"`
+	SendId  string   `json:"sendId,omitempty"`
+	ReplyTo []string `json:"replyTo,omitempty"`
+	Cc      string   `json:"cc,omitempty"`
+	Bcc     string   `json:"bcc,omitempty"`
+}
+
+type SingleSendProperties struct {
+	EmailId           string             `json:"emailId"`
+	Message           *SingleSendMessage `json:"message"`
+	ContactProperties *Contact           `json:"contactProperties,omitempty"`
+	CustomProperties  interface{}        `json:"customProperties,omitempty"`
+}
+
+type SingleEmailSendResponse struct {
+	RequestedAt string `json:"requestedAt"`
+	StatusId    string `json:"statusId"`
+	Status      string `json:"status"`
+}
+
+func (s *TransactionalServiceOp) SingleEmailSend(props *SingleSendProperties) (*SingleEmailSendResponse, error) {
+	resource := &SingleEmailSendResponse{}
+	if err := s.client.Post(fmt.Sprintf("%s/single-email/send", s.transactionalPath), props, resource); err != nil {
+		return nil, err
+	}
+	return resource, nil
+
+}

--- a/marketing_transactional.go
+++ b/marketing_transactional.go
@@ -9,7 +9,7 @@ const transactionalBasePath = "transactional"
 // It can also be associated with other CRM objects such as contact and company.
 // Reference: https://developers.hubspot.com/docs/api/crm/deals
 type TransactionalService interface {
-	SingleEmailSend(props *SingleSendProperties) (*SingleEmailSendResponse, error)
+	SendSingleEmail(props *SendSingleEmailProperties) (*SendSingleEmailResponse, error)
 }
 
 // DealServiceOp handles communication with the product related methods of the HubSpot API.
@@ -20,7 +20,7 @@ type TransactionalServiceOp struct {
 
 var _ TransactionalService = (*TransactionalServiceOp)(nil)
 
-type SingleSendMessage struct {
+type SendSingleEmailMessage struct {
 	To      string   `json:"to"`
 	From    string   `json:"from,omitempty"`
 	SendId  string   `json:"sendId,omitempty"`
@@ -29,21 +29,21 @@ type SingleSendMessage struct {
 	Bcc     string   `json:"bcc,omitempty"`
 }
 
-type SingleSendProperties struct {
-	EmailId           string             `json:"emailId"`
-	Message           *SingleSendMessage `json:"message"`
-	ContactProperties *Contact           `json:"contactProperties,omitempty"`
-	CustomProperties  interface{}        `json:"customProperties,omitempty"`
+type SendSingleEmailProperties struct {
+	EmailId           string                  `json:"emailId"`
+	Message           *SendSingleEmailMessage `json:"message"`
+	ContactProperties *Contact                `json:"contactProperties,omitempty"`
+	CustomProperties  interface{}             `json:"customProperties,omitempty"`
 }
 
-type SingleEmailSendResponse struct {
+type SendSingleEmailResponse struct {
 	RequestedAt string `json:"requestedAt"`
 	StatusId    string `json:"statusId"`
 	Status      string `json:"status"`
 }
 
-func (s *TransactionalServiceOp) SingleEmailSend(props *SingleSendProperties) (*SingleEmailSendResponse, error) {
-	resource := &SingleEmailSendResponse{}
+func (s *TransactionalServiceOp) SendSingleEmail(props *SendSingleEmailProperties) (*SendSingleEmailResponse, error) {
+	resource := &SendSingleEmailResponse{}
 	if err := s.client.Post(fmt.Sprintf("%s/single-email/send", s.transactionalPath), props, resource); err != nil {
 		return nil, err
 	}

--- a/marketing_transactional.go
+++ b/marketing_transactional.go
@@ -23,9 +23,8 @@ type SendSingleEmailMessage struct {
 	From    string   `json:"from,omitempty"`
 	SendId  string   `json:"sendId,omitempty"`
 	ReplyTo []string `json:"replyTo,omitempty"`
-	Cc      []string   `json:"cc,omitempty"`
-	Bcc     []string   `json:"bcc,omitempty"`
-	Bcc     string   `json:"bcc,omitempty"`
+	Cc      []string `json:"cc,omitempty"`
+	Bcc     []string `json:"bcc,omitempty"`
 }
 
 type SendSingleEmailProperties struct {

--- a/marketing_transactional.go
+++ b/marketing_transactional.go
@@ -10,7 +10,7 @@ type TransactionalService interface {
 	SendSingleEmail(props *SendSingleEmailProperties) (*SendSingleEmailResponse, error)
 }
 
-// Provides the default implementation of TransactionService.
+// TransactionalServiceOp provides the default implementation of TransactionService.
 type TransactionalServiceOp struct {
 	transactionalPath string
 	client            *Client

--- a/marketing_transactional.go
+++ b/marketing_transactional.go
@@ -23,7 +23,8 @@ type SendSingleEmailMessage struct {
 	From    string   `json:"from,omitempty"`
 	SendId  string   `json:"sendId,omitempty"`
 	ReplyTo []string `json:"replyTo,omitempty"`
-	Cc      string   `json:"cc,omitempty"`
+	Cc      []string   `json:"cc,omitempty"`
+	Bcc     []string   `json:"bcc,omitempty"`
 	Bcc     string   `json:"bcc,omitempty"`
 }
 

--- a/marketing_transactional.go
+++ b/marketing_transactional.go
@@ -28,7 +28,7 @@ type SendSingleEmailMessage struct {
 }
 
 type SendSingleEmailProperties struct {
-	EmailId           string                  `json:"emailId"`
+	EmailId           int64                   `json:"emailId"`
 	Message           *SendSingleEmailMessage `json:"message"`
 	ContactProperties *Contact                `json:"contactProperties,omitempty"`
 	CustomProperties  interface{}             `json:"customProperties,omitempty"`
@@ -46,5 +46,4 @@ func (s *TransactionalServiceOp) SendSingleEmail(props *SendSingleEmailPropertie
 		return nil, err
 	}
 	return resource, nil
-
 }


### PR DESCRIPTION
This PR adds support for a using  the single email send API.

https://developers.hubspot.com/docs/api/marketing/transactional-emails 

This maps to a `POST /marketing/v3/transactional/single-email/send`

Usage Example:

```go
	props := make(map[string]string)
	props["favoritecolor"] = "green"
	res2, err := client.Marketing.Transactional.SendSingleEmail(&hs.SendSingleEmailProperties{
		EmailId: "xxxxxxxxxxxx",
		Message: &hs.SendSingleEmailMessage{
			To:     "testing@example.com",
			SendId: id.String(),
		},
		ContactProperties: &hs.Contact{
			FirstName: hs.NewString("Stephen"),
		},
		CustomProperties: props,
	})
```

On a successful request, this will return:

```go
&{RequestedAt:2023-01-31T20:34:26.575Z StatusId:Hv-ltMeaTXqm_kmxDE0w8AAAAYYJiboWAWm-0Q== Status:PENDING}
```