### PR TITLE
Add transactional email to README.md and example_test.go

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,17 +201,18 @@ fmt.Println(customDeal.CustomA, customDeal.CustomB)
 
 # API availability
 
-|Category     | API             | Availability    |
-|-------------|-----------------|-----------------|
-|CRM          | Deal            | Available       |
-|CRM          | Contact         | Available       |
-|CMS          | All             | Not Implemented |
-|Conversations| All             | Not Implemented |
-|Events       | All             | Not Implemented |
-|Marketing    | Marketing Email | Available       |
-|Files        | All             | Not Implemented |
-|Settings     | All             | Not Implemented |
-|Webhooks     | All             | Not Implemented |
+|Category     | API                 | Availability    |
+|-------------|---------------------|-----------------|
+|CRM          | Deal                | Available       |
+|CRM          | Contact             | Available       |
+|CMS          | All                 | Not Implemented |
+|Conversations| All                 | Not Implemented |
+|Events       | All                 | Not Implemented |
+|Marketing    | Marketing Email     | Available       |
+|Marketing    | Transactional Email | Available       |
+|Files        | All                 | Not Implemented |
+|Settings     | All                 | Not Implemented |
+|Webhooks     | All                 | Not Implemented |
 
 # Authentication availability
 

--- a/example_test.go
+++ b/example_test.go
@@ -453,3 +453,38 @@ func ExampleMarketingEmailOp_ListStatistics() {
 
 	// // Output:
 }
+
+func ExampleTransactionalServiceOp_SendSingleEmail() {
+	cli, _ := hubspot.NewClient(hubspot.SetPrivateAppToken(os.Getenv("PRIVATE_APP_TOKEN")))
+
+	res, err := cli.Marketing.Transactional.SendSingleEmail(&hubspot.SendSingleEmailProperties{
+		EmailId: 0, // Set proper value.
+		Message: &hubspot.SendSingleEmailMessage{
+			To:      "to@example.com",
+			From:    "from@example.com",
+			SendId:  "SEND_ID",
+			ReplyTo: []string{"reply@example.com"},
+			Cc:      []string{"cc@example.com"},
+			Bcc:     []string{"bcc@example.com"},
+		},
+		ContactProperties: &hubspot.Contact{
+			FirstName:   hubspot.NewString("Bryan"),
+			LastName:    hubspot.NewString("Cooper"),
+			Email:       hubspot.NewString("hubspot@example.com"),
+			MobilePhone: hubspot.NewString("(877) 929-0687"),
+			Zip:         hubspot.NewString("1000001"),
+		},
+		CustomProperties: map[string]string{
+			"custom_email":     "hubspot@example.com",
+			"custom_firstname": "Bryan",
+			"custom_lastname":  "Cooper",
+		},
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("%+v", res)
+
+	// // Output:
+}


### PR DESCRIPTION
## What to do  
Add the contents of Marketing Transactional Email in README.md and example_test.go.

## Background  
https://github.com/belong-inc/go-hubspot/pull/12

## Acceptance criteria  