### PR TITLE
Add delete contact functionality

### DIFF
--- a/contact.go
+++ b/contact.go
@@ -361,3 +361,11 @@ func (s *ContactServiceOp) AssociateAnotherObj(contactID string, conf *Associati
 	}
 	return resource, nil
 }
+
+// Delete deletes a contact.
+func (s *ContactServiceOp) Delete(contactID string) error {
+	if err := s.client.Delete(s.contactPath + "/" + contactID); err != nil {
+		return err
+	}
+	return nil
+}

--- a/contact.go
+++ b/contact.go
@@ -12,6 +12,7 @@ type ContactService interface {
 	Get(contactID string, contact interface{}, option *RequestQueryOption) (*ResponseResource, error)
 	Create(contact interface{}) (*ResponseResource, error)
 	Update(contactID string, contact interface{}) (*ResponseResource, error)
+	Delete(contactID string) error
 	AssociateAnotherObj(contactID string, conf *AssociationConfig) (*ResponseResource, error)
 }
 
@@ -352,6 +353,11 @@ func (s *ContactServiceOp) Update(contactID string, contact interface{}) (*Respo
 	return resource, nil
 }
 
+// Delete deletes a contact.
+func (s *ContactServiceOp) Delete(contactID string) error {
+	return s.client.Delete(s.contactPath + "/" + contactID)
+}
+
 // AssociateAnotherObj associates Contact with another HubSpot objects.
 // If you want to associate a custom object, please use a defined value in HubSpot.
 func (s *ContactServiceOp) AssociateAnotherObj(contactID string, conf *AssociationConfig) (*ResponseResource, error) {
@@ -360,12 +366,4 @@ func (s *ContactServiceOp) AssociateAnotherObj(contactID string, conf *Associati
 		return nil, err
 	}
 	return resource, nil
-}
-
-// Delete deletes a contact.
-func (s *ContactServiceOp) Delete(contactID string) error {
-	if err := s.client.Delete(s.contactPath + "/" + contactID); err != nil {
-		return err
-	}
-	return nil
 }

--- a/contact_test.go
+++ b/contact_test.go
@@ -616,7 +616,6 @@ func TestContactServiceOp_Delete(t *testing.T) {
 		name    string
 		fields  fields
 		args    args
-		want    *hubspot.ResponseResource
 		wantErr error
 	}{
 		{
@@ -631,22 +630,6 @@ func TestContactServiceOp_Delete(t *testing.T) {
 			},
 			args: args{
 				contactID: "contact001",
-			},
-			want: &hubspot.ResponseResource{
-				ID:       "contact001",
-				Archived: false,
-				Properties: &hubspot.Contact{
-					Email:            hubspot.NewString("hubspot@example.com"),
-					FirstName:        hubspot.NewString("Bryan"),
-					HsIsUnworked:     hubspot.NewString("true"),
-					LastName:         hubspot.NewString("Cooper"),
-					MobilePhone:      hubspot.NewString("(877) 929-0687"),
-					Website:          hubspot.NewString("https://example.com"),
-					CreateDate:       &createdAt,
-					LastModifiedDate: &modifyDate,
-				},
-				CreatedAt: &createdAt,
-				UpdatedAt: &updatedAt,
 			},
 			wantErr: nil,
 		},
@@ -663,7 +646,6 @@ func TestContactServiceOp_Delete(t *testing.T) {
 			args: args{
 				contactID: "contact001",
 			},
-			want: nil,
 			wantErr: &hubspot.APIError{
 				HTTPStatusCode: http.StatusBadRequest,
 				Message:        "Invalid input (details will vary based on the error)",


### PR DESCRIPTION
## What to do  
Purpose: Add functionality to delete Contacts.
Following Hubspot's endpoint for [deleting contacts](https://developers.hubspot.com/docs/api/crm/contacts).

## Background  
After creating a new contact for testing, there is no way to delete it through the module. This can become cumbersome, since creating a new contact requires a new email each time. The new `Contact.Delete` function solves this issue:

```go
// Delete deletes a contact.
func (s *ContactServiceOp) Delete(contactID string) error {
    if err := s.client.Delete(s.contactPath + "/" + contactID); err != nil {
        return err
    }
    return nil
}
```

## Acceptance criteria 
Properly delete the requested contact. Returns error if deletion fails.