### PR TITLE
upgrade go and toolset version and run formatter

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       - name: setup
         uses: actions/setup-go@v2
         with:
-          go-version: "1.14"
+          go-version: "1.16"
       - name: lint
         run: make lint
       - name: test

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ test: ## run go test
 
 # Install golangci-lint
 GOLANGCLI_LINT := $(BIN)/golangci-lint
-GOLANGCLI_LINT_VERSION := v1.43.0
+GOLANGCLI_LINT_VERSION := v1.51.0
 $(GOLANGCLI_LINT): | $(BIN) ## Install golangci-lint
 	@curl -sSfL "https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh" | sh -s -- -b $(BIN) $(GOLANGCLI_LINT_VERSION)
 	@chmod +x "$(BIN)/golangci-lint"
@@ -44,7 +44,7 @@ lint: | $(GOLANGCLI_LINT) ## run golangci-lint with config .golangcli.yml
 # Install gofumpt
 # This setting is only available for Mac
 GOFMPT := $(BIN)/gofumpt
-GOFMPT_VERSION := v0.1.0
+GOFMPT_VERSION := v0.4.0
 ifeq "$(UNAME_OS)" "Darwin"
 	GOFMPT_BIN=gofumpt_$(GOFMPT_VERSION)_darwin_amd64
 endif

--- a/crm_imports_start.go
+++ b/crm_imports_start.go
@@ -47,7 +47,9 @@ func addJSONtoMultipart(writer *multipart.Writer, importRequest *CrmImportConfig
 	if err != nil {
 		return err
 	}
-	part.Write([]byte(data))
+	if _, err := part.Write(data); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -63,7 +65,9 @@ func addFilesToMultipart(writer *multipart.Writer, importRequest *CrmImportConfi
 		if err != nil {
 			return err
 		}
-		csvPart.Write(fileData)
+		if _, err := csvPart.Write(fileData); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/crm_imports_test.go
+++ b/crm_imports_test.go
@@ -47,13 +47,13 @@ func createTestCsv(count int) *bytes.Buffer {
 	buf := &bytes.Buffer{}
 	csvwriter := csv.NewWriter(buf)
 	csvHeader := []string{"email", "firstname", "lastname"}
-	csvwriter.Write(csvHeader)
+	_ = csvwriter.Write(csvHeader)
 
 	for i := 0; i < count; i++ {
 		testFirst := fmt.Sprintf("FirstName3%d", i)
 		testLast := fmt.Sprintf("LastName%d", i)
 		testEmail := fmt.Sprintf("test%d@example.com", i)
-		csvwriter.Write([]string{testEmail, testFirst, testLast})
+		_ = csvwriter.Write([]string{testEmail, testFirst, testLast})
 	}
 	csvwriter.Flush()
 	return buf
@@ -104,5 +104,4 @@ func TestImportStart(t *testing.T) {
 	fmt.Printf("%+v\n", res)
 	fmt.Printf("%+v\n", err)
 	// t.Error(1)
-
 }

--- a/doc.go
+++ b/doc.go
@@ -17,6 +17,5 @@ Package hubspot is the root of packages used to access Hubspot APIs.
 
 This library is targeting HubSpot API v3.
 Docs are available in https://developers.hubspot.com/docs/api/overview.
-
 */
 package hubspot

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/belong-inc/go-hubspot
 
-go 1.14
+go 1.16
 
 require (
 	github.com/google/go-cmp v0.5.4

--- a/legacy/doc.go
+++ b/legacy/doc.go
@@ -17,6 +17,5 @@ Package legacy is the package for legacy APIs in Hubspot.
 
 Not all APIs of Hubspot have been migrated v3 therefore components for legacy API is put in this package.
 Docs are available in https://legacydocs.hubspot.com/docs/overview.
-
 */
 package legacy


### PR DESCRIPTION
## What to do
- Fix lint error in master branch.
- Update Go version to use [io.ReadAll](https://github.com/belong-inc/go-hubspot/blob/main/crm_imports_start.go#L62).
- Update linter and formatter version.

## Acceptance criteria