### PR TITLE
Add support for CRM/Tickets API endpoints

### DIFF
--- a/crm.go
+++ b/crm.go
@@ -14,6 +14,7 @@ type CRM struct {
 	Imports    CrmImportsService
 	Schemas    CrmSchemasService
 	Properties CrmPropertiesService
+	Tickets    CrmTicketsServivce
 }
 
 func newCRM(c *Client) *CRM {
@@ -38,6 +39,10 @@ func newCRM(c *Client) *CRM {
 		Properties: &CrmPropertiesServiceOp{
 			crmPropertiesPath: fmt.Sprintf("%s/%s", crmPath, crmPropertiesPath),
 			client:            c,
+		},
+		Tickets: &CrmTicketsServivceOp{
+			crmTicketsPath: fmt.Sprintf("%s/%s/%s", crmPath, objectsBasePath, crmTicketsBasePath),
+			client:         c,
 		},
 	}
 }

--- a/crm_tickets.go
+++ b/crm_tickets.go
@@ -68,7 +68,7 @@ func (s *CrmTicketsServivceOp) Get(ticketId string, option *RequestQueryOption) 
 }
 
 type CrmTicketAssociationTarget struct {
-	Id *HsInt `json:"id,omitempty"`
+	Id *HsStr `json:"id,omitempty"`
 }
 
 type CrmTicketAssociationType struct {

--- a/crm_tickets.go
+++ b/crm_tickets.go
@@ -1,0 +1,141 @@
+package hubspot
+
+import "fmt"
+
+const (
+	crmTicketsBasePath = "tickets"
+)
+
+// CrmTicketsServivce is an interface of CRM tickets endpoints of the HubSpot API.
+// Reference: https://developers.hubspot.com/docs/api/crm/tickets
+type CrmTicketsServivce interface {
+	List(option *RequestQueryOption) (*CrmTicketsList, error)
+	Get(ticketId string, option *RequestQueryOption) (*CrmTicket, error)
+	Create(reqData *CrmTicketCreateRequest) (*CrmTicket, error)
+	Archive(ticketId string) error
+	Update(ticketId string, reqData *CrmTicketUpdateRequest) (*CrmTicket, error)
+	Search(reqData *CrmTicketSearchRequest) (*CrmTicketsList, error)
+}
+
+// CrmTicketsServivceOp handles communication with the CRM tickets endpoints of the HubSpot API.
+type CrmTicketsServivceOp struct {
+	client         *Client
+	crmTicketsPath string
+}
+
+var _ CrmTicketsServivce = (*CrmTicketsServivceOp)(nil)
+
+type CrmTicket struct {
+	Id                    *HsStr                 `json:"id,omitempty"`
+	Properties            map[string]interface{} `json:"properties,omitempty"`
+	PropertiesWithHistory map[string]interface{} `json:"propertiesWithHistory,omitempty"`
+	CreatedAt             *HsTime                `json:"createdAt,omitempty"`
+	UpdatedAt             *HsTime                `json:"updatedAt,omitempty"`
+	Archived              *HsBool                `json:"archived,omitempty"`
+	ArchivedAt            *HsTime                `json:"archivedAt,omitempty"`
+}
+
+type CrmTicketsPagingData struct {
+	After *HsStr `json:"after,omitempty"`
+	Link  *HsStr `json:"link,omitempty"`
+}
+
+type CrmTicketsPaging struct {
+	Next *CrmTicketsPagingData `json:"next,omitempty"`
+}
+
+type CrmTicketsList struct {
+	Total   *HsInt            `json:"total,omitempty"`
+	Results []*CrmTicket      `json:"results"`
+	Paging  *CrmTicketsPaging `json:"paging,omitempty"`
+}
+
+func (s *CrmTicketsServivceOp) List(option *RequestQueryOption) (*CrmTicketsList, error) {
+	var resource CrmTicketsList
+	if err := s.client.Get(s.crmTicketsPath, &resource, option); err != nil {
+		return nil, err
+	}
+	return &resource, nil
+}
+
+func (s *CrmTicketsServivceOp) Get(ticketId string, option *RequestQueryOption) (*CrmTicket, error) {
+	var resource CrmTicket
+	path := fmt.Sprintf("%s/%s", s.crmTicketsPath, ticketId)
+	if err := s.client.Get(path, &resource, option); err != nil {
+		return nil, err
+	}
+	return &resource, nil
+}
+
+type CrmTicketAssociationTarget struct {
+	Id *HsInt `json:"id,omitempty"`
+}
+
+type CrmTicketAssociationType struct {
+	AssociationCategory *HsStr `json:"associationCategory,omitempty"`
+	AssociationTypeId   *HsInt `json:"associationTypeId,omitempty"`
+}
+
+type CrmTicketAssociation struct {
+	To    CrmTicketAssociationTarget `json:"to,omitempty"`
+	Types []CrmTicketAssociationType `json:"type,omitempty"`
+}
+
+type CrmTicketCreateRequest struct {
+	Properties   map[string]interface{}  `json:"properties,omitempty"`
+	Associations []*CrmTicketAssociation `json:"associations,omitempty"`
+}
+
+type CrmTicketUpdateRequest = CrmTicketCreateRequest
+
+func (s *CrmTicketsServivceOp) Create(reqData *CrmTicketCreateRequest) (*CrmTicket, error) {
+	var resource CrmTicket
+	if err := s.client.Post(s.crmTicketsPath, reqData, &resource); err != nil {
+		return nil, err
+	}
+	return &resource, nil
+}
+
+func (s *CrmTicketsServivceOp) Archive(ticketId string) error {
+	path := fmt.Sprintf("%s/%s", s.crmTicketsPath, ticketId)
+	return s.client.Delete(path, nil)
+}
+
+func (s *CrmTicketsServivceOp) Update(ticketId string, reqData *CrmTicketUpdateRequest) (*CrmTicket, error) {
+	var resource CrmTicket
+	path := fmt.Sprintf("%s/%s", s.crmTicketsPath, ticketId)
+	if err := s.client.Patch(path, reqData, &resource); err != nil {
+		return nil, err
+	}
+	return &resource, nil
+}
+
+type CrmTicketSearchFilter struct {
+	Value        *HsStr   `json:"value,omitempty"`
+	HighValue    *HsStr   `json:"highValue,omitempty"`
+	Values       []*HsStr `json:"values,omitempty"`
+	PropertyName *HsStr   `json:"propertyName,omitempty"`
+	Operator     *HsStr   `json:"operator,omitempty"`
+}
+
+type CrmTicketSearchFilterGroup struct {
+	Filters    []*CrmTicketSearchFilter `json:"filters,omitempty"`
+	Sorts      []*HsStr                 `json:"sorts,omitempty"`
+	Query      *HsStr                   `json:"query"`
+	Properties []*HsStr                 `json:"properties,omitempty"`
+	Limit      *HsInt                   `json:"limit,omitempty"`
+	After      *HsInt                   `json:"after,omitempty"`
+}
+
+type CrmTicketSearchRequest struct {
+	FilterGroups []*CrmTicketSearchFilterGroup `json:"filterGroups,omitempty"`
+}
+
+func (s *CrmTicketsServivceOp) Search(reqData *CrmTicketSearchRequest) (*CrmTicketsList, error) {
+	var resource CrmTicketsList
+	path := fmt.Sprintf("%s/search", s.crmTicketsPath)
+	if err := s.client.Post(path, reqData, &resource); err != nil {
+		return nil, err
+	}
+	return &resource, nil
+}

--- a/crm_tickets.go
+++ b/crm_tickets.go
@@ -78,7 +78,7 @@ type CrmTicketAssociationType struct {
 
 type CrmTicketAssociation struct {
 	To    CrmTicketAssociationTarget `json:"to,omitempty"`
-	Types []CrmTicketAssociationType `json:"type,omitempty"`
+	Types []CrmTicketAssociationType `json:"types,omitempty"`
 }
 
 type CrmTicketCreateRequest struct {

--- a/crm_tickets_test.go
+++ b/crm_tickets_test.go
@@ -1,0 +1,102 @@
+package hubspot
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+func TestListTickets(t *testing.T) {
+	t.SkipNow()
+	cli, _ := NewClient(SetPrivateAppToken(os.Getenv("PRIVATE_APP_TOKEN")))
+	opt := &RequestQueryOption{}
+	opt.Properties = []string{"Content"}
+	res, err := cli.CRM.Tickets.List(opt)
+	if err != nil {
+		t.Error(err)
+	}
+	fmt.Printf("%+v\n", res)
+	fmt.Printf("%+v\n", res.Results[0])
+}
+
+func TestGetCrmTicket(t *testing.T) {
+	t.SkipNow()
+	cli, _ := NewClient(SetPrivateAppToken(os.Getenv("PRIVATE_APP_TOKEN")))
+	opt := &RequestQueryOption{}
+	opt.Properties = []string{"Content", "associated_contact_lifecycle_stage", "hubspot_owner_id"}
+	res, err := cli.CRM.Tickets.Get("1594949554", opt)
+	if err != nil {
+		t.Error(err)
+	}
+	fmt.Printf("%+v\n", res)
+}
+
+func TestCreateCrmTicket(t *testing.T) {
+	t.SkipNow()
+	cli, _ := NewClient(SetPrivateAppToken(os.Getenv("PRIVATE_APP_TOKEN")))
+	props := make(map[string]interface{})
+	props["hs_pipeline"] = "30440034"
+	props["hs_pipeline_stage"] = "69304142"
+	props["hubspot_owner_id"] = "301296186"
+	props["hs_ticket_priority"] = "LOW"
+	props["content"] = "this would be some content"
+	props["subject"] = "testing, please ignore"
+	req := &CrmTicketCreateRequest{
+		Properties: props,
+	}
+	res, err := cli.CRM.Tickets.Create(req)
+	if err != nil {
+		t.Error(err)
+	}
+	fmt.Printf("%+v\n", res)
+}
+
+func TestDeleteCrmTicket(t *testing.T) {
+	t.SkipNow()
+	cli, _ := NewClient(SetPrivateAppToken(os.Getenv("PRIVATE_APP_TOKEN")))
+	err := cli.CRM.Tickets.Archive("1594967688")
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestUpdateCrmTicket(t *testing.T) {
+	cli, _ := NewClient(SetPrivateAppToken(os.Getenv("PRIVATE_APP_TOKEN")))
+	props := make(map[string]interface{})
+	props["hs_ticket_priority"] = "HIGH"
+	req := &CrmTicketCreateRequest{
+		Properties: props,
+	}
+	res, err := cli.CRM.Tickets.Update("1594957134", req)
+	if err != nil {
+		t.Error(err)
+	}
+	fmt.Printf("%+v\n", res)
+}
+
+func TestSearchCrmTicket(t *testing.T) {
+	cli, _ := NewClient(SetPrivateAppToken(os.Getenv("PRIVATE_APP_TOKEN")))
+
+	req := &CrmTicketSearchRequest{
+		FilterGroups: []*CrmTicketSearchFilterGroup{
+			{
+				Filters: []*CrmTicketSearchFilter{
+					{
+						Value:        NewString("LOW"),
+						PropertyName: NewString("hs_ticket_priority"),
+						Operator:     NewString("EQ"),
+					},
+				},
+			},
+		},
+	}
+
+	res, err := cli.CRM.Tickets.Search(req)
+	if err != nil {
+		t.Error(err)
+	}
+
+	for _, ticket := range res.Results {
+		fmt.Printf("%+v\n", ticket)
+	}
+}

--- a/crm_tickets_test.go
+++ b/crm_tickets_test.go
@@ -61,6 +61,7 @@ func TestDeleteCrmTicket(t *testing.T) {
 }
 
 func TestUpdateCrmTicket(t *testing.T) {
+	t.SkipNow()
 	cli, _ := NewClient(SetPrivateAppToken(os.Getenv("PRIVATE_APP_TOKEN")))
 	props := make(map[string]interface{})
 	props["hs_ticket_priority"] = "HIGH"
@@ -75,6 +76,8 @@ func TestUpdateCrmTicket(t *testing.T) {
 }
 
 func TestSearchCrmTicket(t *testing.T) {
+	t.SkipNow()
+
 	cli, _ := NewClient(SetPrivateAppToken(os.Getenv("PRIVATE_APP_TOKEN")))
 
 	req := &CrmTicketSearchRequest{


### PR DESCRIPTION
Hello,

This PR adds support for the CRM/Tickets endpoints:
https://developers.hubspot.com/docs/api/crm/tickets

There are issues with the way properties are handled with tickets that makes this a little difficult and I'm not sure how we want to support this in the long term.

1.  Ticket properties can be pretty dynamic, the examples in the hubspot API documentation only show a few possible values but there are many and custom properties are also allowed.  Therefore, I've left the `properties` object as `map[string]interface{}` but I've defined custom objects for basically everything else.

For example, you can have a property defined by hubspot `Date entered 'Closed (Careers)'` if you had a pipeline called "Careers" - and they will define a property for each pipeline type like that.

2.  When retrieving a ticket, there can be top-level dynamic attributes that are based on other objects as specified in your request query parameters.  I'm not sure how to deal with that, at the moment, my code does not support these at all the only way I can see this working is if we made the entire object return as a `map[string]interface{}` or had some sort of secondary un-Marshaling that would allow the user to alternately access everything as a `map[string]interface{}`  

There does not seem to be a native "catch-all" mechanism in `encoding/json`

<img width="477" alt="image" src="https://user-images.githubusercontent.com/131382/235738588-80911ae4-98f9-49f7-8984-b32eccbbfcf4.png">

Other than that, this PR should be pretty clean.
