### PR TITLE
Implements Unmarshaler and Stringer interface for HsInt

### DIFF
--- a/company_test.go
+++ b/company_test.go
@@ -229,7 +229,7 @@ func TestCompanyServiceOp_Get(t *testing.T) {
 				client: hubspot.NewMockClient(&hubspot.MockConfig{
 					Status: http.StatusOK,
 					Header: http.Header{},
-					Body:   []byte(`{"id":"company001","properties":{"annualrevenue":"1000000","city":"Cambridge","createdate":"2019-10-30T03:30:17.883Z","domain":"biglytics.net","hs_lastmodifieddate":"2019-12-07T16:50:06.678Z","industry":"Technology","name":"Biglytics","phone":"(877)929-0687","state":"Massachusetts","custom_name":"biglytics","custom_date":"2019-10-30T03:30:17.883Z","hs_created_by_user_id":""},"createdAt":"2019-10-30T03:30:17.883Z","updatedAt":"2019-12-07T16:50:06.678Z"}`),
+					Body:   []byte(`{"id":"company001","properties":{"annualrevenue":"1000000","city":"Cambridge","createdate":"2019-10-30T03:30:17.883Z","domain":"biglytics.net","hs_lastmodifieddate":"2019-12-07T16:50:06.678Z","industry":"Technology","name":"Biglytics","phone":"(877)929-0687","state":"Massachusetts","custom_name":"biglytics","custom_date":"2019-10-30T03:30:17.883Z","hs_created_by_user_id":"","twitterfollowers":1000},"createdAt":"2019-10-30T03:30:17.883Z","updatedAt":"2019-12-07T16:50:06.678Z"}`),
 				}),
 			},
 			args: args{
@@ -257,6 +257,7 @@ func TestCompanyServiceOp_Get(t *testing.T) {
 						Phone:              hubspot.NewString("(877)929-0687"),
 						State:              hubspot.NewString("Massachusetts"),
 						HsCreatedByUserId:  hubspot.NewInt(0),
+						Twitterfollowers:   hubspot.NewInt(1000),
 					},
 					CustomName: hubspot.NewString("biglytics"),
 					CustomDate: &createdAt,

--- a/company_test.go
+++ b/company_test.go
@@ -223,13 +223,13 @@ func TestCompanyServiceOp_Get(t *testing.T) {
 		wantErr error
 	}{
 		{
-			name: "Successfully get a company",
+			name: "Get a company",
 			fields: fields{
 				companyPath: hubspot.ExportCompanyBasePath,
 				client: hubspot.NewMockClient(&hubspot.MockConfig{
 					Status: http.StatusOK,
 					Header: http.Header{},
-					Body:   []byte(`{"id":"company001","properties":{"annualrevenue":"1000000","city":"Cambridge","createdate":"2019-10-30T03:30:17.883Z","domain":"biglytics.net","hs_lastmodifieddate":"2019-12-07T16:50:06.678Z","industry":"Technology","name":"Biglytics","phone":"(877)929-0687","state":"Massachusetts","custom_name":"biglytics","custom_date":"2019-10-30T03:30:17.883Z","hs_created_by_user_id":"","twitterfollowers":1000},"createdAt":"2019-10-30T03:30:17.883Z","updatedAt":"2019-12-07T16:50:06.678Z"}`),
+					Body:   []byte(`{"id":"company001","properties":{"annualrevenue":"1000000","city":"Cambridge","createdate":"2019-10-30T03:30:17.883Z","domain":"biglytics.net","hs_lastmodifieddate":"2019-12-07T16:50:06.678Z","industry":"Technology","name":"Biglytics","phone":"(877)929-0687","state":"Massachusetts","custom_name":"biglytics","custom_date":"2019-10-30T03:30:17.883Z","hs_created_by_user_id":""},"createdAt":"2019-10-30T03:30:17.883Z","updatedAt":"2019-12-07T16:50:06.678Z"}`),
 				}),
 			},
 			args: args{
@@ -257,7 +257,51 @@ func TestCompanyServiceOp_Get(t *testing.T) {
 						Phone:              hubspot.NewString("(877)929-0687"),
 						State:              hubspot.NewString("Massachusetts"),
 						HsCreatedByUserId:  hubspot.NewInt(0),
-						Twitterfollowers:   hubspot.NewInt(1000),
+					},
+					CustomName: hubspot.NewString("biglytics"),
+					CustomDate: &createdAt,
+				},
+				CreatedAt: &createdAt,
+				UpdatedAt: &updatedAt,
+			},
+			wantErr: nil,
+		},
+		{
+			name: "If the API returns a numeric value when getting a company",
+			fields: fields{
+				companyPath: hubspot.ExportCompanyBasePath,
+				client: hubspot.NewMockClient(&hubspot.MockConfig{
+					Status: http.StatusOK,
+					Header: http.Header{},
+					// NOTE: Normally, numeric types in the HubSpot API are returned as strings (e.g. "", "12345"), but this is to confirm when they are returned as numbers.
+					Body: []byte(`{"id":"company001","properties":{"annualrevenue":1000000,"city":"Cambridge","createdate":"2019-10-30T03:30:17.883Z","domain":"biglytics.net","hs_lastmodifieddate":"2019-12-07T16:50:06.678Z","industry":"Technology","name":"Biglytics","phone":"(877)929-0687","state":"Massachusetts","custom_name":"biglytics","custom_date":"2019-10-30T03:30:17.883Z","hs_created_by_user_id":0},"createdAt":"2019-10-30T03:30:17.883Z","updatedAt":"2019-12-07T16:50:06.678Z"}`),
+				}),
+			},
+			args: args{
+				companyID: "company001",
+				company:   &CustomFields{},
+				option: &hubspot.RequestQueryOption{
+					Properties: []string{
+						"custom_name",
+						"custom_date",
+					},
+				},
+			},
+			want: &hubspot.ResponseResource{
+				ID:       "company001",
+				Archived: false,
+				Properties: &CustomFields{
+					Company: hubspot.Company{
+						Annualrevenue:      hubspot.NewInt(1000000),
+						City:               hubspot.NewString("Cambridge"),
+						Createdate:         &createdAt,
+						Domain:             hubspot.NewString("biglytics.net"),
+						HsLastmodifieddate: &updatedAt,
+						Industry:           hubspot.NewString("Technology"),
+						Name:               hubspot.NewString("Biglytics"),
+						Phone:              hubspot.NewString("(877)929-0687"),
+						State:              hubspot.NewString("Massachusetts"),
+						HsCreatedByUserId:  hubspot.NewInt(0),
 					},
 					CustomName: hubspot.NewString("biglytics"),
 					CustomDate: &createdAt,

--- a/company_test.go
+++ b/company_test.go
@@ -229,7 +229,7 @@ func TestCompanyServiceOp_Get(t *testing.T) {
 				client: hubspot.NewMockClient(&hubspot.MockConfig{
 					Status: http.StatusOK,
 					Header: http.Header{},
-					Body:   []byte(`{"id":"company001","properties":{"city":"Cambridge","createdate":"2019-10-30T03:30:17.883Z","domain":"biglytics.net","hs_lastmodifieddate":"2019-12-07T16:50:06.678Z","industry":"Technology","name":"Biglytics","phone":"(877)929-0687","state":"Massachusetts","custom_name":"biglytics","custom_date":"2019-10-30T03:30:17.883Z"},"createdAt":"2019-10-30T03:30:17.883Z","updatedAt":"2019-12-07T16:50:06.678Z"}`),
+					Body:   []byte(`{"id":"company001","properties":{"annualrevenue":"1000000","city":"Cambridge","createdate":"2019-10-30T03:30:17.883Z","domain":"biglytics.net","hs_lastmodifieddate":"2019-12-07T16:50:06.678Z","industry":"Technology","name":"Biglytics","phone":"(877)929-0687","state":"Massachusetts","custom_name":"biglytics","custom_date":"2019-10-30T03:30:17.883Z","hs_created_by_user_id":""},"createdAt":"2019-10-30T03:30:17.883Z","updatedAt":"2019-12-07T16:50:06.678Z"}`),
 				}),
 			},
 			args: args{
@@ -247,6 +247,7 @@ func TestCompanyServiceOp_Get(t *testing.T) {
 				Archived: false,
 				Properties: &CustomFields{
 					Company: hubspot.Company{
+						Annualrevenue:      hubspot.NewInt(1000000),
 						City:               hubspot.NewString("Cambridge"),
 						Createdate:         &createdAt,
 						Domain:             hubspot.NewString("biglytics.net"),
@@ -255,6 +256,7 @@ func TestCompanyServiceOp_Get(t *testing.T) {
 						Name:               hubspot.NewString("Biglytics"),
 						Phone:              hubspot.NewString("(877)929-0687"),
 						State:              hubspot.NewString("Massachusetts"),
+						HsCreatedByUserId:  hubspot.NewInt(0),
 					},
 					CustomName: hubspot.NewString("biglytics"),
 					CustomDate: &createdAt,

--- a/type.go
+++ b/type.go
@@ -2,6 +2,8 @@ package hubspot
 
 import (
 	"encoding/json"
+	"strconv"
+	"strings"
 	"time"
 )
 
@@ -57,9 +59,8 @@ func NewTime(t time.Time) *HsTime {
 // This is because there are cases where the Time value returned by HubSpot is null or empty string.
 // The time.Time does not support Parse with empty string.
 func (ht *HsTime) UnmarshalJSON(b []byte) error {
-	// FIXME: Initialization is performed on empty string.
 	if len(b) == 0 || string(b) == `""` {
-		return nil
+		return nil // NOTE: Initialization is performed on empty string.
 	}
 	v := &time.Time{}
 	if err := json.Unmarshal(b, v); err != nil {
@@ -99,4 +100,23 @@ type HsInt int
 func NewInt(v int) *HsInt {
 	val := HsInt(v)
 	return &val
+}
+
+// UnmarshalJSON implemented json.Unmarshaler.
+// This is because there are cases where the Int value returned by HubSpot is "" or "12345".
+func (hi *HsInt) UnmarshalJSON(b []byte) error {
+	if len(b) == 0 || string(b) == `""` {
+		return nil // NOTE: Initialization is performed on 0.
+	}
+	i, err := strconv.Atoi(strings.Replace(string(b), `"`, ``, -1))
+	if err != nil {
+		return err
+	}
+	*hi = HsInt(i)
+	return nil
+}
+
+// String implemented Stringer.
+func (hi *HsInt) String() string {
+	return strconv.Itoa(int(*hi))
 }


### PR DESCRIPTION
## What to do  
Fix an Company API error when unmarshaling company objects.
- Added `UnmarshalJSON` and `String` methods to HsInt.

## Background  

> The property types for the company model seems to be incorrect.
For unclear reasons Hubspot uses strings for basically everything.

https://github.com/belong-inc/go-hubspot/pull/26

## Acceptance criteria  