### PR TITLE
Refactor wrong int types to string types & update tests

### DIFF
--- a/company_model.go
+++ b/company_model.go
@@ -7,7 +7,7 @@ type Company struct {
 	AboutUs                                 *HsStr  `json:"about_us,omitempty"`
 	Address                                 *HsStr  `json:"address,omitempty"`
 	Address2                                *HsStr  `json:"address2,omitempty"`
-	Annualrevenue                           *HsInt  `json:"annualrevenue,omitempty"`
+	Annualrevenue                           *HsStr  `json:"annualrevenue,omitempty"`
 	City                                    *HsStr  `json:"city,omitempty"`
 	Closedate                               *HsTime `json:"closedate,omitempty"`
 	Country                                 *HsStr  `json:"country,omitempty"`
@@ -37,12 +37,12 @@ type Company struct {
 	HsAnalyticsLatestSourceData1            *HsStr  `json:"hs_analytics_latest_source_data_1,omitempty"`
 	HsAnalyticsLatestSourceData2            *HsStr  `json:"hs_analytics_latest_source_data_2,omitempty"`
 	HsAnalyticsLatestSourceTimestamp        *HsTime `json:"hs_analytics_latest_source_timestamp,omitempty"`
-	HsAnalyticsNumPageViews                 *HsInt  `json:"hs_analytics_num_page_views,omitempty"`
-	HsAnalyticsNumVisits                    *HsInt  `json:"hs_analytics_num_visits,omitempty"`
+	HsAnalyticsNumPageViews                 *HsStr  `json:"hs_analytics_num_page_views,omitempty"`
+	HsAnalyticsNumVisits                    *HsStr  `json:"hs_analytics_num_visits,omitempty"`
 	HsAnalyticsSource                       *HsStr  `json:"hs_analytics_source,omitempty"`
 	HsAnalyticsSourceData1                  *HsStr  `json:"hs_analytics_source_data_1,omitempty"`
 	HsAnalyticsSourceData2                  *HsStr  `json:"hs_analytics_source_data_2,omitempty"`
-	HsCreatedByUserId                       *HsInt  `json:"hs_created_by_user_id,omitempty"`
+	HsCreatedByUserId                       *HsStr  `json:"hs_created_by_user_id,omitempty"`
 	HsCreatedate                            *HsTime `json:"hs_createdate,omitempty"`
 	HsIdealCustomerProfile                  *HsStr  `json:"hs_ideal_customer_profile,omitempty"`
 	HsIsTargetAccount                       *HsBool `json:"hs_is_target_account,omitempty"`
@@ -53,14 +53,14 @@ type Company struct {
 	HsLastmodifieddate                      *HsTime `json:"hs_lastmodifieddate,omitempty"`
 	HsLeadStatus                            *HsStr  `json:"hs_lead_status,omitempty"`
 	HsMergedObjectIds                       *HsStr  `json:"hs_merged_object_ids,omitempty"`
-	HsNumBlockers                           *HsInt  `json:"hs_num_blockers,omitempty"`
-	HsNumChildCompanies                     *HsInt  `json:"hs_num_child_companies,omitempty"`
-	HsNumContactsWithBuyingRoles            *HsInt  `json:"hs_num_contacts_with_buying_roles,omitempty"`
-	HsNumDecisionMakers                     *HsInt  `json:"hs_num_decision_makers,omitempty"`
-	HsNumOpenDeals                          *HsInt  `json:"hs_num_open_deals,omitempty"`
-	HsObjectId                              *HsInt  `json:"hs_object_id,omitempty"`
-	HsParentCompanyId                       *HsInt  `json:"hs_parent_company_id,omitempty"`
-	HsTotalDealValue                        *HsInt  `json:"hs_total_deal_value,omitempty"`
+	HsNumBlockers                           *HsStr  `json:"hs_num_blockers,omitempty"`
+	HsNumChildCompanies                     *HsStr  `json:"hs_num_child_companies,omitempty"`
+	HsNumContactsWithBuyingRoles            *HsStr  `json:"hs_num_contacts_with_buying_roles,omitempty"`
+	HsNumDecisionMakers                     *HsStr  `json:"hs_num_decision_makers,omitempty"`
+	HsNumOpenDeals                          *HsStr  `json:"hs_num_open_deals,omitempty"`
+	HsObjectId                              *HsStr  `json:"hs_object_id,omitempty"`
+	HsParentCompanyId                       *HsStr  `json:"hs_parent_company_id,omitempty"`
+	HsTotalDealValue                        *HsStr  `json:"hs_total_deal_value,omitempty"`
 	HubspotOwnerAssigneddate                *HsTime `json:"hubspot_owner_assigneddate,omitempty"`
 	HubspotOwnerId                          *HsStr  `json:"hubspot_owner_id,omitempty"`
 	HubspotTeamId                           *HsStr  `json:"hubspot_team_id,omitempty"`
@@ -73,22 +73,22 @@ type Company struct {
 	NotesLastContacted                      *HsTime `json:"notes_last_contacted,omitempty"`
 	NotesLastUpdated                        *HsTime `json:"notes_last_updated,omitempty"`
 	NotesNextActivityDate                   *HsTime `json:"notes_next_activity_date,omitempty"`
-	NumAssociatedContacts                   *HsInt  `json:"num_associated_contacts,omitempty"`
-	NumAssociatedDeals                      *HsInt  `json:"num_associated_deals,omitempty"`
-	NumContactedNotes                       *HsInt  `json:"num_contacted_notes,omitempty"`
-	NumConversionEvents                     *HsInt  `json:"num_conversion_events,omitempty"`
-	Numberofemployees                       *HsInt  `json:"numberofemployees,omitempty"`
+	NumAssociatedContacts                   *HsStr  `json:"num_associated_contacts,omitempty"`
+	NumAssociatedDeals                      *HsStr  `json:"num_associated_deals,omitempty"`
+	NumContactedNotes                       *HsStr  `json:"num_contacted_notes,omitempty"`
+	NumConversionEvents                     *HsStr  `json:"num_conversion_events,omitempty"`
+	Numberofemployees                       *HsStr  `json:"numberofemployees,omitempty"`
 	Phone                                   *HsStr  `json:"phone,omitempty"`
 	RecentConversionDate                    *HsTime `json:"recent_conversion_date,omitempty"`
 	RecentConversionEventName               *HsStr  `json:"recent_conversion_event_name,omitempty"`
-	RecentDealAmount                        *HsInt  `json:"recent_deal_amount,omitempty"`
+	RecentDealAmount                        *HsStr  `json:"recent_deal_amount,omitempty"`
 	RecentDealCloseDate                     *HsTime `json:"recent_deal_close_date,omitempty"`
 	State                                   *HsStr  `json:"state,omitempty"`
 	Timezone                                *HsStr  `json:"timezone,omitempty"`
 	TotalMoneyRaised                        *HsStr  `json:"total_money_raised,omitempty"`
-	TotalRevenue                            *HsInt  `json:"total_revenue,omitempty"`
+	TotalRevenue                            *HsStr  `json:"total_revenue,omitempty"`
 	Twitterbio                              *HsStr  `json:"twitterbio,omitempty"`
-	Twitterfollowers                        *HsInt  `json:"twitterfollowers,omitempty"`
+	Twitterfollowers                        *HsStr  `json:"twitterfollowers,omitempty"`
 	Twitterhandle                           *HsStr  `json:"twitterhandle,omitempty"`
 	Type                                    *HsStr  `json:"type,omitempty"`
 	WebTechnologies                         *HsStr  `json:"web_technologies,omitempty"`

--- a/company_test.go
+++ b/company_test.go
@@ -247,7 +247,7 @@ func TestCompanyServiceOp_Get(t *testing.T) {
 				Archived: false,
 				Properties: &CustomFields{
 					Company: hubspot.Company{
-						Annualrevenue:      hubspot.NewInt(1000000),
+						Annualrevenue:      hubspot.NewString("1000000"),
 						City:               hubspot.NewString("Cambridge"),
 						Createdate:         &createdAt,
 						Domain:             hubspot.NewString("biglytics.net"),
@@ -256,7 +256,7 @@ func TestCompanyServiceOp_Get(t *testing.T) {
 						Name:               hubspot.NewString("Biglytics"),
 						Phone:              hubspot.NewString("(877)929-0687"),
 						State:              hubspot.NewString("Massachusetts"),
-						HsCreatedByUserId:  hubspot.NewInt(0),
+						HsCreatedByUserId:  hubspot.NewString("0"),
 					},
 					CustomName: hubspot.NewString("biglytics"),
 					CustomDate: &createdAt,
@@ -292,7 +292,7 @@ func TestCompanyServiceOp_Get(t *testing.T) {
 				Archived: false,
 				Properties: &CustomFields{
 					Company: hubspot.Company{
-						Annualrevenue:      hubspot.NewInt(1000000),
+						Annualrevenue:      hubspot.NewString("1000000"),
 						City:               hubspot.NewString("Cambridge"),
 						Createdate:         &createdAt,
 						Domain:             hubspot.NewString("biglytics.net"),
@@ -301,7 +301,7 @@ func TestCompanyServiceOp_Get(t *testing.T) {
 						Name:               hubspot.NewString("Biglytics"),
 						Phone:              hubspot.NewString("(877)929-0687"),
 						State:              hubspot.NewString("Massachusetts"),
-						HsCreatedByUserId:  hubspot.NewInt(0),
+						HsCreatedByUserId:  hubspot.NewString("0"),
 					},
 					CustomName: hubspot.NewString("biglytics"),
 					CustomDate: &createdAt,


### PR DESCRIPTION
## What to do  
Refactor wrong int types into string types in the Company struct.
## Background  
The current hubspot API returns the company response with different field types than what is described in the company struct
## Acceptance criteria  
