### PR TITLE
Add NewBool function to convert regular bool to hubspot boolean

### DIFF
--- a/type.go
+++ b/type.go
@@ -33,6 +33,12 @@ func (hs *HsStr) String() string {
 // HsBool is defined to marshal the HubSpot boolean fields of `true`, `"true"`, and so on, into a bool type.
 type HsBool bool
 
+// NewBoolean returns pointer HsBool(bool)
+func NewBoolean(b bool) *HsBool {
+	v := HsBool(b)
+	return &v
+}
+
 // UnmarshalJSON implemented json.Unmarshaler.
 // This is because there are cases where the Time value returned by HubSpot is null or "true" / "false".
 func (hb *HsBool) UnmarshalJSON(b []byte) error {

--- a/type_test.go
+++ b/type_test.go
@@ -39,6 +39,26 @@ func TestHsStr_String(t *testing.T) {
 	}
 }
 
+func TestHsBool_Boolean(t *testing.T) {
+	tests := []struct {
+		input    bool
+		expected bool
+	}{
+		{true, true},
+		{false, false},
+	}
+
+	for _, test := range tests {
+		result := hubspot.NewBoolean(test.input)
+		if result == nil {
+			t.Errorf("NewBoolean(%v) = nil; want *HsBool with value %v", test.input, test.expected)
+		}
+		if *result != hubspot.HsBool(test.expected) {
+			t.Errorf("NewBoolean(%v) = %v; want %v", test.input, *result, test.expected)
+		}
+	}
+}
+
 var testDate = time.Date(2022, time.February, 28, 0, 0, 0, 0, time.UTC)
 
 func TestHsTime_String(t *testing.T) {

--- a/type_test.go
+++ b/type_test.go
@@ -50,9 +50,6 @@ func TestHsBool_Boolean(t *testing.T) {
 
 	for _, test := range tests {
 		result := hubspot.NewBoolean(test.input)
-		if result == nil {
-			t.Errorf("NewBoolean(%v) = nil; want *HsBool with value %v", test.input, test.expected)
-		}
 		if *result != hubspot.HsBool(test.expected) {
 			t.Errorf("NewBoolean(%v) = %v; want %v", test.input, *result, test.expected)
 		}


### PR DESCRIPTION
## What to do  

I need to convert regular bool to hubspot.Bool type. 

I got this scenario trying to get a object deal with custom properties. 

## Acceptance criteria  

Can convert regular boolean to hubspot boolean type