### PR TITLE
feat: upgrade to go123

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,15 +6,27 @@ on:
 
 jobs:
   test:
+    name: Setup environment
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: ["1.23", "1.24"]
+    outputs:
+      cache-key: ${{ steps.cache-setup.outputs.cache-key }}
     steps:
-      - name: checkout
-        uses: actions/checkout@v2
-      - name: setup
-        uses: actions/setup-go@v2
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up Go
+        id: go-setup
+        uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
         with:
-          go-version: "1.16"
+          go-version: ${{ matrix.go-version }}
+          check-latest: true
+          cache-dependency-path: "**/*.sum"
+  
       - name: lint
         run: make lint
+
       - name: test
         run: make test

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,9 +1,9 @@
 run:
   timeout: 2m
-  skip-dirs:
-    - scripts
+  go: "1.23" # Set Go version to 1.23
 
 linters:
+  disable-all: true
   enable:
     - goimports
     - govet
@@ -15,4 +15,3 @@ linters:
     - gofumpt
     - goconst
     - unconvert
-  disable-all: true

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ test: ## run go test. If you need test options, pass them in like OPTIONS="-v"
 
 # Install golangci-lint
 GOLANGCLI_LINT := $(BIN)/golangci-lint
-GOLANGCLI_LINT_VERSION := v1.51.0
+GOLANGCLI_LINT_VERSION := v1.64.6
 $(GOLANGCLI_LINT): | $(BIN) ## Install golangci-lint
 	@curl -sSfL "https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh" | sh -s -- -b $(BIN) $(GOLANGCLI_LINT_VERSION)
 	@chmod +x "$(BIN)/golangci-lint"
@@ -49,9 +49,11 @@ lint: | $(GOLANGCLI_LINT) ## run golangci-lint with config .golangcli.yml
 # Install gofumpt
 # This setting is only available for Mac
 GOFMPT := $(BIN)/gofumpt
-GOFMPT_VERSION := v0.4.0
-ifeq "$(UNAME_OS)" "Darwin"
-	GOFMPT_BIN=gofumpt_$(GOFMPT_VERSION)_darwin_amd64
+GOFMPT_VERSION := v0.7.0
+ifeq ($(UNAME_OS),Darwin)
+    GOFMPT_BIN=gofumpt_$(GOFMPT_VERSION)_darwin_amd64
+else ifeq ($(UNAME_OS),Linux)
+    GOFMPT_BIN=gofumpt_$(GOFMPT_VERSION)_linux_amd64
 endif
 
 $(GOFMPT): | $(BIN) ## Install gofumpt

--- a/company_test.go
+++ b/company_test.go
@@ -5,8 +5,9 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/belong-inc/go-hubspot"
 	"github.com/google/go-cmp/cmp"
+
+	"github.com/belong-inc/go-hubspot"
 )
 
 func TestCompanyServiceOp_Create(t *testing.T) {

--- a/contact_test.go
+++ b/contact_test.go
@@ -5,8 +5,9 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/belong-inc/go-hubspot"
 	"github.com/google/go-cmp/cmp"
+
+	"github.com/belong-inc/go-hubspot"
 )
 
 func TestContactServiceOp_Create(t *testing.T) {

--- a/deal_test.go
+++ b/deal_test.go
@@ -5,8 +5,9 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/belong-inc/go-hubspot"
 	"github.com/google/go-cmp/cmp"
+
+	"github.com/belong-inc/go-hubspot"
 )
 
 func TestDealServiceOp_Create(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/belong-inc/go-hubspot
 
-go 1.16
+go 1.23
 
 require (
 	github.com/google/go-cmp v0.5.4
-	github.com/google/go-querystring v1.0.0
+	github.com/google/go-querystring v1.1.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,7 @@
+github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4 h1:L8R9j+yAqZuZjsqh/z+F1NCffTKKLShY6zXTItVIZ8M=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
-github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
+github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
+github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/gohubspot_test.go
+++ b/gohubspot_test.go
@@ -3,15 +3,16 @@ package hubspot_test
 import (
 	"bytes"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"reflect"
 	"testing"
 	"time"
 
-	hubspot "github.com/belong-inc/go-hubspot"
 	"github.com/google/go-cmp/cmp"
+
+	hubspot "github.com/belong-inc/go-hubspot"
 )
 
 var (
@@ -358,7 +359,7 @@ func TestClient_NewRequest(t *testing.T) {
 				t.Errorf("NewRequest() header mismatch: want %s got %s", tt.want.header, got.Header)
 				return
 			}
-			b, _ := ioutil.ReadAll(got.Body)
+			b, _ := io.ReadAll(got.Body)
 			if string(tt.want.body) != string(b) {
 				t.Errorf("NewRequest() body mismatch: want %s got %s", string(tt.want.body), string(b))
 			}
@@ -515,7 +516,7 @@ func TestCheckResponseError(t *testing.T) {
 			args: args{
 				r: &http.Response{
 					StatusCode: http.StatusBadRequest,
-					Body:       ioutil.NopCloser(bytes.NewBuffer([]byte(`{"message": "Invalid input (details will vary based on the error)","correlationId": "aeb5f871-7f07-4993-9211-075dc63e7cbf","category": "VALIDATION_ERROR","links": {"knowledge-base": "https://www.hubspot.com/products/service/knowledge-base"}}`))),
+					Body:       io.NopCloser(bytes.NewBuffer([]byte(`{"message": "Invalid input (details will vary based on the error)","correlationId": "aeb5f871-7f07-4993-9211-075dc63e7cbf","category": "VALIDATION_ERROR","links": {"knowledge-base": "https://www.hubspot.com/products/service/knowledge-base"}}`))),
 				},
 			},
 			wantErr: &hubspot.APIError{
@@ -533,7 +534,7 @@ func TestCheckResponseError(t *testing.T) {
 			args: args{
 				r: &http.Response{
 					StatusCode: http.StatusBadRequest,
-					Body:       ioutil.NopCloser(bytes.NewBuffer([]byte(`{"status": "error","message": "Property values were not valid: [{\"isValid\":false,\"message\":\"Email address bcooper@example.con is invalid\",\"error\":\"INVALID_EMAIL\",\"name\":\"email\"}]","correlationId":"aeb5f871-7f07-4993-9211-075dc63e7cbf","category":"VALIDATION_ERROR"}`))),
+					Body:       io.NopCloser(bytes.NewBuffer([]byte(`{"status": "error","message": "Property values were not valid: [{\"isValid\":false,\"message\":\"Email address bcooper@example.con is invalid\",\"error\":\"INVALID_EMAIL\",\"name\":\"email\"}]","correlationId":"aeb5f871-7f07-4993-9211-075dc63e7cbf","category":"VALIDATION_ERROR"}`))),
 				},
 			},
 			wantErr: &hubspot.APIError{
@@ -557,7 +558,7 @@ func TestCheckResponseError(t *testing.T) {
 			args: args{
 				r: &http.Response{
 					StatusCode: http.StatusBadRequest,
-					Body:       ioutil.NopCloser(bytes.NewBuffer([]byte(`{"status": "error","message": "Property values were not valid: [{\"isValid\":false,\"message\":\"Email address bcooper@example.con is invalid\",\"error\":\"INVALID_EMAIL\",\"name\":\"email\"},{'json':unexpected}]","correlationId":"aeb5f871-7f07-4993-9211-075dc63e7cbf","category":"VALIDATION_ERROR"}`))),
+					Body:       io.NopCloser(bytes.NewBuffer([]byte(`{"status": "error","message": "Property values were not valid: [{\"isValid\":false,\"message\":\"Email address bcooper@example.con is invalid\",\"error\":\"INVALID_EMAIL\",\"name\":\"email\"},{'json':unexpected}]","correlationId":"aeb5f871-7f07-4993-9211-075dc63e7cbf","category":"VALIDATION_ERROR"}`))),
 				},
 			},
 			wantErr: &hubspot.APIError{

--- a/mock_test.go
+++ b/mock_test.go
@@ -2,7 +2,7 @@ package hubspot
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 )
@@ -40,7 +40,7 @@ func NewMockHTTPClient(conf *MockConfig) *http.Client {
 		Transport: RoundTripFunc(func(req *http.Request) *http.Response {
 			return &http.Response{
 				StatusCode: conf.Status,
-				Body:       ioutil.NopCloser(bytes.NewBuffer(conf.Body)),
+				Body:       io.NopCloser(bytes.NewBuffer(conf.Body)),
 				Header:     conf.Header,
 			}
 		}),

--- a/oauth.go
+++ b/oauth.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -60,14 +60,14 @@ func (otm *OAuthTokenManager) fetchTokenFromHubSpot() (tokenByte []byte, err err
 	defer res.Body.Close()
 
 	if isErrorStatusCode(res.StatusCode) {
-		b, err := ioutil.ReadAll(res.Body)
+		b, err := io.ReadAll(res.Body)
 		if err != nil {
 			return nil, err
 		}
 		return nil, fmt.Errorf("failed to authorize: %s", string(b))
 	}
 
-	return ioutil.ReadAll(res.Body)
+	return io.ReadAll(res.Body)
 }
 
 func (otm *OAuthTokenManager) refreshToken(tokenByte []byte) (newToken *OAuthToken, err error) {

--- a/oauth_test.go
+++ b/oauth_test.go
@@ -8,8 +8,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/belong-inc/go-hubspot"
 	"github.com/google/go-cmp/cmp"
+
+	"github.com/belong-inc/go-hubspot"
 )
 
 func TestOAuthTokenManager_RetrieveToken(t *testing.T) {

--- a/options_test.go
+++ b/options_test.go
@@ -6,8 +6,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/belong-inc/go-hubspot"
 	"github.com/google/go-cmp/cmp"
+
+	"github.com/belong-inc/go-hubspot"
 )
 
 func TestWithAPIVersion(t *testing.T) {

--- a/query_test.go
+++ b/query_test.go
@@ -3,8 +3,9 @@ package hubspot_test
 import (
 	"testing"
 
-	"github.com/belong-inc/go-hubspot"
 	"github.com/google/go-cmp/cmp"
+
+	"github.com/belong-inc/go-hubspot"
 )
 
 func TestRequestQueryOption_setupProperties(t *testing.T) {

--- a/type_test.go
+++ b/type_test.go
@@ -4,8 +4,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/belong-inc/go-hubspot"
 	"github.com/google/go-cmp/cmp"
+
+	"github.com/belong-inc/go-hubspot"
 )
 
 func TestHsStr_String(t *testing.T) {


### PR DESCRIPTION
## Description
 
- [x] Upgrade package to go 1.23
- [x] Upgrade golangci-lint to v1.64.6(latest)
- [x] Upgrade gofmt to v0.7.0(compatible with go 1.23)
- [x] go 1.16 is no longer maintained and creates a security risk for this project.
- [x] This PR updates the GitHub Actions workflow to support matrix builds for Go versions up to 1.24. The project is currently pinned to Go 1.16, which is outdated and no longer maintained. 

### Why Upgrade? 
- **Security**: Go 1.16 no longer receives security updates, exposing the project to vulnerabilities.  I *STRONGLY* recommend upgrading to `go 1.23`
- **Performance**: Newer versions offer significant optimizations, improving build times and runtime efficiency.  
- **Modern Features**: Go 1.17+ introduces `go:embed`, module graph pruning, and improved dependency management.  
- **Better CI Reliability**: Testing across multiple Go versions ensures compatibility and prevents regressions.  

### Changes  
- Updated GitHub Actions to test against Go versions 1.23 to 1.24.  
- Ensured compatibility with newer Go versions.  
