### PR TITLE
Add custom search for Company and Contact objects

### DIFF
--- a/company.go
+++ b/company.go
@@ -16,6 +16,7 @@ type CompanyService interface {
 	AssociateAnotherObj(companyID string, conf *AssociationConfig) (*ResponseResource, error)
 	SearchByDomain(domain string) (*CompanySearchResponse, error)
 	SearchByName(name string) (*CompanySearchResponse, error)
+	Search(req *CompanySearchRequest) (*CompanySearchResponse, error)
 }
 
 // CompanyServiceOp handles communication with the product related methods of the HubSpot API.
@@ -78,6 +79,10 @@ func (s *CompanyServiceOp) AssociateAnotherObj(companyID string, conf *Associati
 	return resource, nil
 }
 
+type CompanySearchRequest struct {
+	FilterGroups []FilterGroup `json:"filterGroups"`
+}
+
 // CompanySearchResponse represents the response from searching companies.
 type CompanySearchResponse struct {
 	Total   int64           `json:"total"`
@@ -137,5 +142,14 @@ func (s *CompanyServiceOp) SearchByName(name string) (*CompanySearchResponse, er
 		return nil, err
 	}
 
+	return resource, nil
+}
+
+// Search searches for a company by any given property filters, including custom properties.
+func (s *CompanyServiceOp) Search(req *CompanySearchRequest) (*CompanySearchResponse, error) {
+	resource := &CompanySearchResponse{}
+	if err := s.client.Post(s.companyPath+"/search", req, resource); err != nil {
+		return nil, err
+	}
 	return resource, nil
 }

--- a/company_test.go
+++ b/company_test.go
@@ -1,7 +1,9 @@
 package hubspot_test
 
 import (
+	"fmt"
 	"net/http"
+	"os"
 	"reflect"
 	"testing"
 
@@ -483,5 +485,33 @@ func TestCompanyServiceOp_AssociateAnotherObj(t *testing.T) {
 				t.Errorf("AssociateAnotherObj() response mismatch (-want +got):%s", diff)
 			}
 		})
+	}
+}
+
+func TestCompanyServiceOp_Search(t *testing.T) {
+	t.SkipNow()
+	cli, _ := hubspot.NewClient(hubspot.SetPrivateAppToken(os.Getenv("PRIVATE_APP_TOKEN")))
+
+	req := &hubspot.CompanySearchRequest{
+		FilterGroups: []hubspot.FilterGroup{
+			{
+				Filters: []hubspot.Filter{
+					{
+						PropertyName: "twitterhandle",
+						Value:        "tweetiepie",
+						Operator:     "EQ",
+					},
+				},
+			},
+		},
+	}
+
+	res, err := cli.CRM.Company.Search(req)
+	if err != nil {
+		t.Error(err)
+	}
+
+	for _, result := range res.Results {
+		fmt.Printf("%+v\n", result)
 	}
 }

--- a/contact.go
+++ b/contact.go
@@ -15,6 +15,7 @@ type ContactService interface {
 	Delete(contactID string) error
 	AssociateAnotherObj(contactID string, conf *AssociationConfig) (*ResponseResource, error)
 	SearchByEmail(email string) (*ContactSearchResponse, error)
+	Search(req *ContactSearchRequest) (*ContactSearchResponse, error)
 }
 
 // ContactServiceOp handles communication with the product related methods of the HubSpot API.
@@ -421,5 +422,14 @@ func (s *ContactServiceOp) SearchByEmail(email string) (*ContactSearchResponse, 
 		return nil, err
 	}
 
+	return resource, nil
+}
+
+// Search searches for a contact by any given property filters, including custom properties.
+func (s *ContactServiceOp) Search(req *ContactSearchRequest) (*ContactSearchResponse, error) {
+	resource := &ContactSearchResponse{}
+	if err := s.client.Post(s.contactPath+"/search", req, resource); err != nil {
+		return nil, err
+	}
 	return resource, nil
 }

--- a/contact_test.go
+++ b/contact_test.go
@@ -1,7 +1,9 @@
 package hubspot_test
 
 import (
+	"fmt"
 	"net/http"
+	"os"
 	"reflect"
 	"testing"
 
@@ -737,5 +739,33 @@ func TestContactServiceOp_AssociateAnotherObj(t *testing.T) {
 				t.Errorf("AssociateAnotherObj() response mismatch (-want +got):%s", diff)
 			}
 		})
+	}
+}
+
+func TestContactServiceOp_Search(t *testing.T) {
+	t.SkipNow()
+	cli, _ := hubspot.NewClient(hubspot.SetPrivateAppToken(os.Getenv("PRIVATE_APP_TOKEN")))
+
+	req := &hubspot.ContactSearchRequest{
+		FilterGroups: []hubspot.FilterGroup{
+			{
+				Filters: []hubspot.Filter{
+					{
+						PropertyName: "work_email",
+						Value:        "test@test.com",
+						Operator:     "EQ",
+					},
+				},
+			},
+		},
+	}
+
+	res, err := cli.CRM.Contact.Search(req)
+	if err != nil {
+		t.Error(err)
+	}
+
+	for _, result := range res.Results {
+		fmt.Printf("%+v\n", result)
 	}
 }


### PR DESCRIPTION
### Summary

This PR adds support for searching Companies and Contacts using the [HubSpot CRM Search API](https://developers.hubspot.com/docs/api/crm/search). These capabilities are useful for users who need to locate existing records by property filters (e.g., email, company name) before creating or updating them.

✨ What's Included
* Companies.Search(ctx, request) method
* Contacts.Search(ctx, request) method
* Integration tests (disabled by default)

🔍 Example Usage
```
req := goHubspot.CompanySearchRequest{
  FilterGroups: []goHubspot.FilterGroup{
    {
        Filters: []goHubspot.Filter{
	  {
	    PropertyName: "company_number",
	    Value:        "123456",
	    Operator:     "EQ",
	  },
	},
    },
  },
}

res, err := client.CRM.Company.Search(&searchReq)
```

### Motivation

We have a need to search for existing records before creating new ones, to allow for "upsert" functionality. We need to search by custom properties that are relevant to our business domain, so unfortunately the currenty `SearchByX` methods are too restrictive.  These generic search functions will give users of this library more flexibility. 
