### PR TITLE
Refactor search method and generalizing search filter

### DIFF
--- a/company.go
+++ b/company.go
@@ -100,7 +100,7 @@ type CompanyResult struct {
 // SearchByDomain searches for a company by domain.
 // EXPERIMENTAL: This method is experimental and the interface may change in the future to support custom properties.
 func (s *CompanyServiceOp) SearchByDomain(domain string) (*CompanySearchResponse, error) {
-	filter := &CompanySearchRequest{
+	req := &CompanySearchRequest{
 		SearchOptions: SearchOptions{
 			FilterGroups: []FilterGroup{
 				{
@@ -115,13 +115,13 @@ func (s *CompanyServiceOp) SearchByDomain(domain string) (*CompanySearchResponse
 			},
 		},
 	}
-	return s.Search(filter)
+	return s.Search(req)
 }
 
 // SearchByName searches for a company by name.
 // EXPERIMENTAL: This method is experimental and the interface may change in the future to support custom properties.
 func (s *CompanyServiceOp) SearchByName(name string) (*CompanySearchResponse, error) {
-	filter := &CompanySearchRequest{
+	req := &CompanySearchRequest{
 		SearchOptions: SearchOptions{
 			FilterGroups: []FilterGroup{
 				{
@@ -136,7 +136,7 @@ func (s *CompanyServiceOp) SearchByName(name string) (*CompanySearchResponse, er
 			},
 		},
 	}
-	return s.Search(filter)
+	return s.Search(req)
 }
 
 // Search searches for a company by any given property filters, including custom properties.

--- a/company.go
+++ b/company.go
@@ -80,7 +80,7 @@ func (s *CompanyServiceOp) AssociateAnotherObj(companyID string, conf *Associati
 }
 
 type CompanySearchRequest struct {
-	FilterGroups []FilterGroup `json:"filterGroups"`
+	SearchOptions
 }
 
 // CompanySearchResponse represents the response from searching companies.
@@ -101,13 +101,15 @@ type CompanyResult struct {
 // EXPERIMENTAL: This method is experimental and the interface may change in the future to support custom properties.
 func (s *CompanyServiceOp) SearchByDomain(domain string) (*CompanySearchResponse, error) {
 	filter := &CompanySearchRequest{
-		FilterGroups: []FilterGroup{
-			{
-				Filters: []Filter{
-					{
-						PropertyName: "domain",
-						Operator:     "EQ",
-						Value:        domain,
+		SearchOptions: SearchOptions{
+			FilterGroups: []FilterGroup{
+				{
+					Filters: []Filter{
+						{
+							PropertyName: "domain",
+							Operator:     EQ,
+							Value:        NewString(domain),
+						},
 					},
 				},
 			},
@@ -120,13 +122,15 @@ func (s *CompanyServiceOp) SearchByDomain(domain string) (*CompanySearchResponse
 // EXPERIMENTAL: This method is experimental and the interface may change in the future to support custom properties.
 func (s *CompanyServiceOp) SearchByName(name string) (*CompanySearchResponse, error) {
 	filter := &CompanySearchRequest{
-		FilterGroups: []FilterGroup{
-			{
-				Filters: []Filter{
-					{
-						PropertyName: "name",
-						Operator:     "EQ",
-						Value:        name,
+		SearchOptions: SearchOptions{
+			FilterGroups: []FilterGroup{
+				{
+					Filters: []Filter{
+						{
+							PropertyName: "name",
+							Operator:     EQ,
+							Value:        NewString(name),
+						},
 					},
 				},
 			},

--- a/company.go
+++ b/company.go
@@ -29,7 +29,7 @@ var _ CompanyService = (*CompanyServiceOp)(nil)
 
 // Get gets a Company.
 // In order to bind the get content, a structure must be specified as an argument.
-// Also, if you want to gets a custom field, you need to specify the field name.
+// Also, if you want to get a custom field, you need to specify the field name.
 // If you specify a non-existent field, it will be ignored.
 // e.g. &hubspot.RequestQueryOption{ Properties: []string{"custom_a", "custom_b"}}
 func (s *CompanyServiceOp) Get(companyID string, company interface{}, option *RequestQueryOption) (*ResponseResource, error) {
@@ -98,8 +98,9 @@ type CompanyResult struct {
 }
 
 // SearchByDomain searches for a company by domain.
+// EXPERIMENTAL: This method is experimental and the interface may change in the future to support custom properties.
 func (s *CompanyServiceOp) SearchByDomain(domain string) (*CompanySearchResponse, error) {
-	req := &ContactSearchRequest{
+	filter := &CompanySearchRequest{
 		FilterGroups: []FilterGroup{
 			{
 				Filters: []Filter{
@@ -112,18 +113,13 @@ func (s *CompanyServiceOp) SearchByDomain(domain string) (*CompanySearchResponse
 			},
 		},
 	}
-
-	resource := &CompanySearchResponse{}
-	if err := s.client.Post(s.companyPath+"/search", req, resource); err != nil {
-		return nil, err
-	}
-
-	return resource, nil
+	return s.Search(filter)
 }
 
 // SearchByName searches for a company by name.
+// EXPERIMENTAL: This method is experimental and the interface may change in the future to support custom properties.
 func (s *CompanyServiceOp) SearchByName(name string) (*CompanySearchResponse, error) {
-	req := &ContactSearchRequest{
+	filter := &CompanySearchRequest{
 		FilterGroups: []FilterGroup{
 			{
 				Filters: []Filter{
@@ -136,16 +132,11 @@ func (s *CompanyServiceOp) SearchByName(name string) (*CompanySearchResponse, er
 			},
 		},
 	}
-
-	resource := &CompanySearchResponse{}
-	if err := s.client.Post(s.companyPath+"/search", req, resource); err != nil {
-		return nil, err
-	}
-
-	return resource, nil
+	return s.Search(filter)
 }
 
 // Search searches for a company by any given property filters, including custom properties.
+// EXPERIMENTAL: This method is experimental and the interface may change in the future to support custom properties.
 func (s *CompanyServiceOp) Search(req *CompanySearchRequest) (*CompanySearchResponse, error) {
 	resource := &CompanySearchResponse{}
 	if err := s.client.Post(s.companyPath+"/search", req, resource); err != nil {

--- a/company_test.go
+++ b/company_test.go
@@ -493,19 +493,20 @@ func TestCompanyServiceOp_Search(t *testing.T) {
 	cli, _ := hubspot.NewClient(hubspot.SetPrivateAppToken(os.Getenv("PRIVATE_APP_TOKEN")))
 
 	req := &hubspot.CompanySearchRequest{
-		FilterGroups: []hubspot.FilterGroup{
-			{
-				Filters: []hubspot.Filter{
-					{
-						PropertyName: "twitterhandle",
-						Value:        "tweetiepie",
-						Operator:     "EQ",
+		SearchOptions: hubspot.SearchOptions{
+			FilterGroups: []hubspot.FilterGroup{
+				{
+					Filters: []hubspot.Filter{
+						{
+							PropertyName: "twitterhandle",
+							Operator:     hubspot.EQ,
+							Value:        hubspot.NewString("tweetiepie"),
+						},
 					},
 				},
 			},
 		},
 	}
-
 	res, err := cli.CRM.Company.Search(req)
 	if err != nil {
 		t.Error(err)

--- a/contact.go
+++ b/contact.go
@@ -31,19 +31,6 @@ type ContactSearchRequest struct {
 	FilterGroups []FilterGroup `json:"filterGroups"`
 }
 
-// FilterGroup represents a group of filters.
-type FilterGroup struct {
-	Filters []Filter `json:"filters"`
-}
-
-// Filter represents a single filter.
-type Filter struct {
-	PropertyName string   `json:"propertyName"`
-	Operator     string   `json:"operator"`
-	Values       []string `json:"values,omitempty"`
-	Value        string   `json:"value,omitempty"`
-}
-
 // ContactSearchResponse represents the response from searching contacts.
 type ContactSearchResponse struct {
 	Total   int64           `json:"total"`
@@ -351,7 +338,7 @@ var defaultContactFields = []string{
 
 // Get gets a contact.
 // In order to bind the get content, a structure must be specified as an argument.
-// Also, if you want to gets a custom field, you need to specify the field name.
+// Also, if you want to get a custom field, you need to specify the field name.
 // If you specify a non-existent field, it will be ignored.
 // e.g. &hubspot.RequestQueryOption{ Properties: []string{"custom_a", "custom_b"}}
 func (s *ContactServiceOp) Get(contactID string, contact interface{}, option *RequestQueryOption) (*ResponseResource, error) {
@@ -402,8 +389,9 @@ func (s *ContactServiceOp) AssociateAnotherObj(contactID string, conf *Associati
 }
 
 // SearchByEmail searches for a contact by email.
+// EXPERIMENTAL: This method is experimental and the interface may change in the future to support custom properties.
 func (s *ContactServiceOp) SearchByEmail(email string) (*ContactSearchResponse, error) {
-	req := &ContactSearchRequest{
+	filter := &ContactSearchRequest{
 		FilterGroups: []FilterGroup{
 			{
 				Filters: []Filter{
@@ -416,16 +404,11 @@ func (s *ContactServiceOp) SearchByEmail(email string) (*ContactSearchResponse, 
 			},
 		},
 	}
-
-	resource := &ContactSearchResponse{}
-	if err := s.client.Post(s.contactPath+"/search", req, resource); err != nil {
-		return nil, err
-	}
-
-	return resource, nil
+	return s.Search(filter)
 }
 
 // Search searches for a contact by any given property filters, including custom properties.
+// EXPERIMENTAL: This method is experimental and the interface may change in the future to support custom properties.
 func (s *ContactServiceOp) Search(req *ContactSearchRequest) (*ContactSearchResponse, error) {
 	resource := &ContactSearchResponse{}
 	if err := s.client.Post(s.contactPath+"/search", req, resource); err != nil {

--- a/contact.go
+++ b/contact.go
@@ -28,7 +28,7 @@ var _ ContactService = (*ContactServiceOp)(nil)
 
 // ContactSearchRequest represents the request body for searching contacts.
 type ContactSearchRequest struct {
-	FilterGroups []FilterGroup `json:"filterGroups"`
+	SearchOptions
 }
 
 // ContactSearchResponse represents the response from searching contacts.
@@ -391,20 +391,22 @@ func (s *ContactServiceOp) AssociateAnotherObj(contactID string, conf *Associati
 // SearchByEmail searches for a contact by email.
 // EXPERIMENTAL: This method is experimental and the interface may change in the future to support custom properties.
 func (s *ContactServiceOp) SearchByEmail(email string) (*ContactSearchResponse, error) {
-	filter := &ContactSearchRequest{
-		FilterGroups: []FilterGroup{
-			{
-				Filters: []Filter{
-					{
-						PropertyName: "email",
-						Operator:     "EQ",
-						Value:        email,
+	req := &ContactSearchRequest{
+		SearchOptions: SearchOptions{
+			FilterGroups: []FilterGroup{
+				{
+					Filters: []Filter{
+						{
+							PropertyName: "email",
+							Operator:     EQ,
+							Value:        NewString(email),
+						},
 					},
 				},
 			},
 		},
 	}
-	return s.Search(filter)
+	return s.Search(req)
 }
 
 // Search searches for a contact by any given property filters, including custom properties.

--- a/contact_test.go
+++ b/contact_test.go
@@ -747,13 +747,15 @@ func TestContactServiceOp_Search(t *testing.T) {
 	cli, _ := hubspot.NewClient(hubspot.SetPrivateAppToken(os.Getenv("PRIVATE_APP_TOKEN")))
 
 	req := &hubspot.ContactSearchRequest{
-		FilterGroups: []hubspot.FilterGroup{
-			{
-				Filters: []hubspot.Filter{
-					{
-						PropertyName: "work_email",
-						Value:        "test@test.com",
-						Operator:     "EQ",
+		SearchOptions: hubspot.SearchOptions{
+			FilterGroups: []hubspot.FilterGroup{
+				{
+					Filters: []hubspot.Filter{
+						{
+							PropertyName: "work_email",
+							Operator:     hubspot.EQ,
+							Value:        hubspot.NewString("test@test.com"),
+						},
 					},
 				},
 			},

--- a/crm.go
+++ b/crm.go
@@ -16,7 +16,7 @@ type CRM struct {
 	Note       NoteService
 	Schemas    CrmSchemasService
 	Properties CrmPropertiesService
-	Tickets    CrmTicketsServivce
+	Tickets    CrmTicketsService
 }
 
 func newCRM(c *Client) *CRM {
@@ -50,7 +50,7 @@ func newCRM(c *Client) *CRM {
 			crmPropertiesPath: fmt.Sprintf("%s/%s", crmPath, crmPropertiesPath),
 			client:            c,
 		},
-		Tickets: &CrmTicketsServivceOp{
+		Tickets: &CrmTicketsServiceOp{
 			crmTicketsPath: fmt.Sprintf("%s/%s/%s", crmPath, objectsBasePath, crmTicketsBasePath),
 			client:         c,
 		},

--- a/crm_tickets.go
+++ b/crm_tickets.go
@@ -6,9 +6,9 @@ const (
 	crmTicketsBasePath = "tickets"
 )
 
-// CrmTicketsServivce is an interface of CRM tickets endpoints of the HubSpot API.
+// CrmTicketsService is an interface of CRM tickets endpoints of the HubSpot API.
 // Reference: https://developers.hubspot.com/docs/api/crm/tickets
-type CrmTicketsServivce interface {
+type CrmTicketsService interface {
 	List(option *RequestQueryOption) (*CrmTicketsList, error)
 	Get(ticketId string, option *RequestQueryOption) (*CrmTicket, error)
 	Create(reqData *CrmTicketCreateRequest) (*CrmTicket, error)
@@ -17,13 +17,13 @@ type CrmTicketsServivce interface {
 	Search(reqData *CrmTicketSearchRequest) (*CrmTicketsList, error)
 }
 
-// CrmTicketsServivceOp handles communication with the CRM tickets endpoints of the HubSpot API.
-type CrmTicketsServivceOp struct {
+// CrmTicketsServiceOp handles communication with the CRM tickets endpoints of the HubSpot API.
+type CrmTicketsServiceOp struct {
 	client         *Client
 	crmTicketsPath string
 }
 
-var _ CrmTicketsServivce = (*CrmTicketsServivceOp)(nil)
+var _ CrmTicketsService = (*CrmTicketsServiceOp)(nil)
 
 type CrmTicket struct {
 	Id                    *HsStr                 `json:"id,omitempty"`
@@ -50,7 +50,7 @@ type CrmTicketsList struct {
 	Paging  *CrmTicketsPaging `json:"paging,omitempty"`
 }
 
-func (s *CrmTicketsServivceOp) List(option *RequestQueryOption) (*CrmTicketsList, error) {
+func (s *CrmTicketsServiceOp) List(option *RequestQueryOption) (*CrmTicketsList, error) {
 	var resource CrmTicketsList
 	if err := s.client.Get(s.crmTicketsPath, &resource, option); err != nil {
 		return nil, err
@@ -58,7 +58,7 @@ func (s *CrmTicketsServivceOp) List(option *RequestQueryOption) (*CrmTicketsList
 	return &resource, nil
 }
 
-func (s *CrmTicketsServivceOp) Get(ticketId string, option *RequestQueryOption) (*CrmTicket, error) {
+func (s *CrmTicketsServiceOp) Get(ticketId string, option *RequestQueryOption) (*CrmTicket, error) {
 	var resource CrmTicket
 	path := fmt.Sprintf("%s/%s", s.crmTicketsPath, ticketId)
 	if err := s.client.Get(path, &resource, option); err != nil {
@@ -88,7 +88,7 @@ type CrmTicketCreateRequest struct {
 
 type CrmTicketUpdateRequest = CrmTicketCreateRequest
 
-func (s *CrmTicketsServivceOp) Create(reqData *CrmTicketCreateRequest) (*CrmTicket, error) {
+func (s *CrmTicketsServiceOp) Create(reqData *CrmTicketCreateRequest) (*CrmTicket, error) {
 	var resource CrmTicket
 	if err := s.client.Post(s.crmTicketsPath, reqData, &resource); err != nil {
 		return nil, err
@@ -96,12 +96,12 @@ func (s *CrmTicketsServivceOp) Create(reqData *CrmTicketCreateRequest) (*CrmTick
 	return &resource, nil
 }
 
-func (s *CrmTicketsServivceOp) Archive(ticketId string) error {
+func (s *CrmTicketsServiceOp) Archive(ticketId string) error {
 	path := fmt.Sprintf("%s/%s", s.crmTicketsPath, ticketId)
 	return s.client.Delete(path, nil)
 }
 
-func (s *CrmTicketsServivceOp) Update(ticketId string, reqData *CrmTicketUpdateRequest) (*CrmTicket, error) {
+func (s *CrmTicketsServiceOp) Update(ticketId string, reqData *CrmTicketUpdateRequest) (*CrmTicket, error) {
 	var resource CrmTicket
 	path := fmt.Sprintf("%s/%s", s.crmTicketsPath, ticketId)
 	if err := s.client.Patch(path, reqData, &resource); err != nil {
@@ -131,7 +131,7 @@ type CrmTicketSearchRequest struct {
 	FilterGroups []*CrmTicketSearchFilterGroup `json:"filterGroups,omitempty"`
 }
 
-func (s *CrmTicketsServivceOp) Search(reqData *CrmTicketSearchRequest) (*CrmTicketsList, error) {
+func (s *CrmTicketsServiceOp) Search(reqData *CrmTicketSearchRequest) (*CrmTicketsList, error) {
 	var resource CrmTicketsList
 	path := fmt.Sprintf("%s/search", s.crmTicketsPath)
 	if err := s.client.Post(path, reqData, &resource); err != nil {

--- a/deal.go
+++ b/deal.go
@@ -13,6 +13,8 @@ type DealService interface {
 	Create(deal interface{}) (*ResponseResource, error)
 	Update(dealID string, deal interface{}) (*ResponseResource, error)
 	AssociateAnotherObj(dealID string, conf *AssociationConfig) (*ResponseResource, error)
+	SearchByName(dealName string) (*DealSearchResponse, error)
+	Search(req *DealSearchRequest) (*DealSearchResponse, error)
 }
 
 // DealServiceOp handles communication with the product related methods of the HubSpot API.
@@ -112,7 +114,7 @@ var defaultDealFields = []string{
 
 // Get gets a deal.
 // In order to bind the get content, a structure must be specified as an argument.
-// Also, if you want to gets a custom field, you need to specify the field name.
+// Also, if you want to get a custom field, you need to specify the field name.
 // If you specify a non-existent field, it will be ignored.
 // e.g. &hubspot.RequestQueryOption{ Properties: []string{"custom_a", "custom_b"}}
 func (s *DealServiceOp) Get(dealID string, deal interface{}, option *RequestQueryOption) (*ResponseResource, error) {
@@ -157,27 +159,31 @@ func (s *DealServiceOp) AssociateAnotherObj(dealID string, conf *AssociationConf
 	return resource, nil
 }
 
-// SearchDeals searches for deals by deal name.
-func (s *DealServiceOp) SearchDeals(dealName string) (*DealSearchResponse, error) {
-	resource := &DealSearchResponse{Total: 0, Results: []DealResponse{}}
-	req := &DealSearchRequest{
+// SearchByName searches for deals by deal name.
+// EXPERIMENTAL: This method is experimental and the interface may change in the future to support custom properties.
+func (s *DealServiceOp) SearchByName(dealName string) (*DealSearchResponse, error) {
+	filter := &DealSearchRequest{
 		FilterGroups: []FilterGroup{
 			{
 				Filters: []Filter{
 					{
 						PropertyName: "dealname",
-						Operator:     "EQ",
+						Operator:     EQ,
 						Value:        dealName,
 					},
 				},
 			},
 		},
 	}
+	return s.Search(filter)
+}
 
-	// Send the POST request to HubSpot API
+// Search searches for deals based on the provided search request.
+// EXPERIMENTAL: This method is experimental and the interface may change in the future to support custom properties.
+func (s *DealServiceOp) Search(req *DealSearchRequest) (*DealSearchResponse, error) {
+	resource := &DealSearchResponse{}
 	if err := s.client.Post(dealBasePath+"/search", req, resource); err != nil {
 		return nil, err
 	}
-
 	return resource, nil
 }

--- a/deal.go
+++ b/deal.go
@@ -25,7 +25,7 @@ type DealServiceOp struct {
 
 // DealSearchRequest represents the request body for searching deals.
 type DealSearchRequest struct {
-	FilterGroups []FilterGroup `json:"filterGroups,omitempty"`
+	SearchOptions
 }
 
 // DealSearchResponse represents the structure of the response from the deal search endpoint.
@@ -162,20 +162,22 @@ func (s *DealServiceOp) AssociateAnotherObj(dealID string, conf *AssociationConf
 // SearchByName searches for deals by deal name.
 // EXPERIMENTAL: This method is experimental and the interface may change in the future to support custom properties.
 func (s *DealServiceOp) SearchByName(dealName string) (*DealSearchResponse, error) {
-	filter := &DealSearchRequest{
-		FilterGroups: []FilterGroup{
-			{
-				Filters: []Filter{
-					{
-						PropertyName: "dealname",
-						Operator:     EQ,
-						Value:        dealName,
+	req := &DealSearchRequest{
+		SearchOptions: SearchOptions{
+			FilterGroups: []FilterGroup{
+				{
+					Filters: []Filter{
+						{
+							PropertyName: "dealname",
+							Operator:     EQ,
+							Value:        NewString(dealName),
+						},
 					},
 				},
 			},
 		},
 	}
-	return s.Search(filter)
+	return s.Search(req)
 }
 
 // Search searches for deals based on the provided search request.

--- a/filter.go
+++ b/filter.go
@@ -1,0 +1,35 @@
+package hubspot
+
+// Operator is search for HubSpot API filters.
+// It defines the operators that can be used in search filters for various HubSpot objects such as contacts, companies, deals, and tickets.
+// https://developers.hubspot.com/docs/guides/api/crm/search#filter-search-results
+type Operator string
+
+const (
+	LT               Operator = "LT"                 // Less than the specified value.
+	LTE              Operator = "LTE"                // Less than or equal to the specified value.
+	GT               Operator = "GT"                 // Greater than the specified value.
+	GTE              Operator = "GTE"                // Greater than or equal to the specified value.
+	EQ               Operator = "EQ"                 // Equal to the specified value.
+	NEQ              Operator = "NEQ"                // Not equal to the specified value.
+	Between          Operator = "BETWEEN"            // Within the specified range. In your request, use key-value pairs to set highValue and value. Refer to the example below the table.
+	IN               Operator = "IN"                 // Included within the specified list. Searches by exact match. In your request, include the list values in a values array. When searching a string property with this operator, values must be lowercase. Refer to the example below the table.
+	NotIN            Operator = "NOT_IN"             // Not included within the specified list. In your request, include the list values in a values array. When searching a string property with this operator, values must be lowercase.
+	HasProperty      Operator = "HAS_PROPERTY"       // Has a value for the specified property.
+	NotHasProperty   Operator = "NOT_HAS_PROPERTY"   // Doesn't have a value for the specified property.
+	ContainsToken    Operator = "CONTAINS_TOKEN"     // Contains a token. In your request, you can use wildcards (*) to complete a partial search. For example, use the value *@hubspot.com to retrieve contacts with a HubSpot email address.
+	NotContainsToken Operator = "NOT_CONTAINS_TOKEN" // Doesn't contain a token.
+)
+
+// FilterGroup represents a group of filters for HubSpot search requests.
+type FilterGroup struct {
+	Filters []Filter `json:"filters"`
+}
+
+// Filter represents a single filter for HubSpot search requests.
+type Filter struct {
+	PropertyName string   `json:"propertyName"`
+	Operator     Operator `json:"operator"`
+	Values       []string `json:"values,omitempty"`
+	Value        string   `json:"value,omitempty"`
+}

--- a/search.go
+++ b/search.go
@@ -21,15 +21,37 @@ const (
 	NotContainsToken Operator = "NOT_CONTAINS_TOKEN" // Doesn't contain a token.
 )
 
+// SearchOptions represents the options for searching HubSpot objects.
+type SearchOptions struct {
+	FilterGroups []FilterGroup `json:"filterGroups,omitempty"` // A list of filter groups, each containing one or more filters.
+	Sorts        []Sort        `json:"sorts,omitempty"`
+	Query        string        `json:"query,omitempty"`
+	Properties   []string      `json:"properties,omitempty"`
+	Limit        int           `json:"limit,omitempty"` // The maximum number of entries per page is 200, the default is 10.
+	After        int           `json:"after,omitempty"` // The offset for pagination, used to retrieve the next page of results.
+}
+
 // FilterGroup represents a group of filters for HubSpot search requests.
 type FilterGroup struct {
-	Filters []Filter `json:"filters"`
+	Filters []Filter `json:"filters,omitempty"`
 }
 
 // Filter represents a single filter for HubSpot search requests.
 type Filter struct {
 	PropertyName string   `json:"propertyName"`
 	Operator     Operator `json:"operator"`
-	Values       []string `json:"values,omitempty"`
-	Value        string   `json:"value,omitempty"`
+	Values       []HsStr  `json:"values,omitempty"`
+	Value        *HsStr   `json:"value,omitempty"`
+}
+
+type SortDirection string
+
+const (
+	Asc  SortDirection = "ASCENDING"
+	Desc SortDirection = "DESCENDING"
+)
+
+type Sort struct {
+	PropertyName string        `json:"propertyName"`
+	Direction    SortDirection `json:"direction"`
 }

--- a/search.go
+++ b/search.go
@@ -42,6 +42,7 @@ type Filter struct {
 	Operator     Operator `json:"operator"`
 	Values       []HsStr  `json:"values,omitempty"`
 	Value        *HsStr   `json:"value,omitempty"`
+	HighValue    *HsStr   `json:"highValue,omitempty"`
 }
 
 type SortDirection string


### PR DESCRIPTION
## What to do  
- Refactoring parameters when calling SearchAPI for CRM objects.
- Fixed typos in interface names etc.

The implementation of SearchAPI calls is currently in an experimental stage. 
In the future, I would like to implement custom properties and syntactic sugar for search parameters.

## Background
Generalizing parameters when calling SearchAPI.

## Acceptance criteria  