### PR TITLE
Support for unix timestamp format to HsTime

### DIFF
--- a/type.go
+++ b/type.go
@@ -68,11 +68,20 @@ func (ht *HsTime) UnmarshalJSON(b []byte) error {
 	if len(b) == 0 || string(b) == `""` {
 		return nil // NOTE: Initialization is performed on empty string.
 	}
-	v := &time.Time{}
-	if err := json.Unmarshal(b, v); err != nil {
-		return err
+
+	if strings.Contains(string(b), "-") {
+		v := &time.Time{}
+		if err := json.Unmarshal(b, v); err != nil {
+			return err
+		}
+		*ht = HsTime(*v)
 	}
-	*ht = HsTime(*v)
+	if unix, err := strconv.ParseInt(string(b), 10, 64); err == nil {
+		seconds := unix / 1000
+		nanoseconds := (unix % 1000) * 1000000
+		t := time.Unix(seconds, nanoseconds)
+		*ht = HsTime(t)
+	}
 	return nil
 }
 

--- a/type.go
+++ b/type.go
@@ -64,9 +64,10 @@ func NewTime(t time.Time) *HsTime {
 // UnmarshalJSON implemented json.Unmarshaler.
 // This is because there are cases where the Time value returned by HubSpot is null or empty string.
 // The time.Time does not support Parse with empty string.
+// Supports both unix timestamps (milliseconds) and ISO 8601 date strings.
 func (ht *HsTime) UnmarshalJSON(b []byte) error {
-	if len(b) == 0 || string(b) == `""` {
-		return nil // NOTE: Initialization is performed on empty string.
+	if len(b) == 0 || string(b) == `""` || string(b) == "null" {
+		return nil // NOTE: Initialization is performed on empty string or null.
 	}
 
 	if strings.Contains(string(b), "-") {
@@ -75,12 +76,12 @@ func (ht *HsTime) UnmarshalJSON(b []byte) error {
 			return err
 		}
 		*ht = HsTime(*v)
+		return nil
 	}
 	if unix, err := strconv.ParseInt(string(b), 10, 64); err == nil {
-		seconds := unix / 1000
-		nanoseconds := (unix % 1000) * 1000000
-		t := time.Unix(seconds, nanoseconds)
+		t := time.Unix(unix/1000, (unix%1000)*1000000).UTC()
 		*ht = HsTime(t)
+		return nil
 	}
 	return nil
 }


### PR DESCRIPTION
## What to do  
Add Parse process for UnixTimestamp in HsTime Unmarshal process.

## Background  
HubSpot's Date field may return a UnixTimestamp format, so the unmarshal process must support both DateString and UnixTimestamp.

## Acceptance criteria  